### PR TITLE
feat: Remaining DDL — RENAME COLUMN, DROP TABLE, CREATE/DROP SCHEMA, RENAME TABLE

### DIFF
--- a/src/ducklake_polars/__init__.py
+++ b/src/ducklake_polars/__init__.py
@@ -22,6 +22,11 @@ __all__ = [
     "update_ducklake",
     "alter_ducklake_add_column",
     "alter_ducklake_drop_column",
+    "alter_ducklake_rename_column",
+    "drop_ducklake_table",
+    "create_ducklake_schema",
+    "drop_ducklake_schema",
+    "rename_ducklake_table",
     "DuckLakeCatalog",
 ]
 
@@ -432,3 +437,193 @@ def alter_ducklake_drop_column(
 
     with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
         writer.drop_column(table, col_name, schema_name=schema)
+
+
+def alter_ducklake_rename_column(
+    path: str | Path,
+    table: str,
+    old_col_name: str,
+    new_col_name: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+) -> None:
+    """
+    Rename a column in a DuckLake table.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Currently only SQLite backends are supported for writes.
+    table
+        Name of the table to alter.
+    old_col_name
+        Current name of the column.
+    new_col_name
+        New name for the column.
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+
+    Raises
+    ------
+    ValueError
+        If the table or column does not exist, or if the new name
+        already exists.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        writer.rename_column(
+            table, old_col_name, new_col_name, schema_name=schema
+        )
+
+
+def drop_ducklake_table(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+) -> None:
+    """
+    Drop a table from a DuckLake catalog.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Currently only SQLite backends are supported for writes.
+    table
+        Name of the table to drop.
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+
+    Raises
+    ------
+    ValueError
+        If the table does not exist.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        writer.drop_table(table, schema_name=schema)
+
+
+def create_ducklake_schema(
+    path: str | Path,
+    schema_name: str,
+    *,
+    data_path: str | Path | None = None,
+) -> None:
+    """
+    Create a new schema in a DuckLake catalog.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Currently only SQLite backends are supported for writes.
+    schema_name
+        Name of the schema to create.
+    data_path
+        Override the data path stored in the catalog.
+
+    Raises
+    ------
+    ValueError
+        If the schema already exists.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        writer.create_schema(schema_name)
+
+
+def drop_ducklake_schema(
+    path: str | Path,
+    schema_name: str,
+    *,
+    cascade: bool = False,
+    data_path: str | Path | None = None,
+) -> None:
+    """
+    Drop a schema from a DuckLake catalog.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Currently only SQLite backends are supported for writes.
+    schema_name
+        Name of the schema to drop.
+    cascade
+        If True, drop all tables in the schema first.
+        If False (default), raise if the schema contains tables.
+    data_path
+        Override the data path stored in the catalog.
+
+    Raises
+    ------
+    ValueError
+        If the schema does not exist or contains tables (when cascade=False).
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        writer.drop_schema(schema_name, cascade=cascade)
+
+
+def rename_ducklake_table(
+    path: str | Path,
+    old_table: str,
+    new_table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+) -> None:
+    """
+    Rename a table in a DuckLake catalog.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Currently only SQLite backends are supported for writes.
+    old_table
+        Current name of the table.
+    new_table
+        New name for the table.
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+
+    Raises
+    ------
+    ValueError
+        If the old table does not exist or if the new name already exists.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        writer.rename_table(old_table, new_table, schema_name=schema)

--- a/src/ducklake_polars/_writer.py
+++ b/src/ducklake_polars/_writer.py
@@ -1363,6 +1363,406 @@ class DuckLakeCatalogWriter:
         con.commit()
 
     # ------------------------------------------------------------------
+    # ALTER TABLE: RENAME COLUMN
+    # ------------------------------------------------------------------
+
+    def rename_column(
+        self,
+        table_name: str,
+        old_column_name: str,
+        new_column_name: str,
+        *,
+        schema_name: str = "main",
+    ) -> None:
+        """Rename a column in an existing table.
+
+        DuckLake tracks renames by ending the old column row and inserting
+        a new row with the same ``column_id`` but a different name. Old
+        Parquet files keep the physical old name; the reader uses column
+        history to resolve renames.
+        """
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        table_id = self._table_exists(table_name, schema_name, snap_id)
+        if table_id is None:
+            msg = f"Table '{schema_name}.{table_name}' not found"
+            raise ValueError(msg)
+
+        # Find the source column
+        columns = self._get_columns_for_table(table_id, snap_id)
+        target_col: tuple[int, str, str, int | None] | None = None
+        for col_id, col_name, col_type, parent in columns:
+            if col_name == old_column_name:
+                target_col = (col_id, col_name, col_type, parent)
+            if col_name == new_column_name:
+                msg = f"Column '{new_column_name}' already exists in '{schema_name}.{table_name}'"
+                raise ValueError(msg)
+
+        if target_col is None:
+            msg = f"Column '{old_column_name}' not found in '{schema_name}.{table_name}'"
+            raise ValueError(msg)
+
+        col_id, _old_name, col_type, parent_column = target_col
+
+        # Look up the full column row for column_order and nulls_allowed
+        row = con.execute(
+            "SELECT column_order, nulls_allowed, initial_default, default_value "
+            "FROM ducklake_column "
+            "WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+            [table_id, col_id],
+        ).fetchone()
+        col_order = row[0]
+        nulls_allowed = row[1]
+        initial_default = row[2]
+        default_value = row[3]
+
+        new_schema_ver = schema_ver + 1
+
+        # Create snapshot
+        new_snap = self._create_snapshot(new_schema_ver, next_cat_id, next_file_id)
+
+        # End the old column row
+        con.execute(
+            "UPDATE ducklake_column SET end_snapshot = ? "
+            "WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+            [new_snap, table_id, col_id],
+        )
+
+        # Insert a new row with the same column_id but new name
+        con.execute(
+            "INSERT INTO ducklake_column "
+            "(column_id, begin_snapshot, end_snapshot, table_id, column_order, "
+            "column_name, column_type, initial_default, default_value, "
+            "nulls_allowed, parent_column) "
+            "VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                col_id, new_snap, table_id, col_order,
+                new_column_name, col_type, initial_default, default_value,
+                nulls_allowed, parent_column,
+            ],
+        )
+
+        # Record schema version
+        con.execute(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version) "
+            "VALUES (?, ?)",
+            [new_snap, new_schema_ver],
+        )
+
+        # Record change
+        self._record_change(new_snap, f"altered_table:{table_id}")
+
+        con.commit()
+
+    # ------------------------------------------------------------------
+    # DROP TABLE
+    # ------------------------------------------------------------------
+
+    def _end_all_columns(self, table_id: int, snapshot_id: int, new_snap: int) -> None:
+        """Mark all active columns as ended at new_snap."""
+        con = self._connect()
+        con.execute(
+            "UPDATE ducklake_column SET end_snapshot = ? "
+            "WHERE table_id = ? AND begin_snapshot <= ? "
+            "AND (end_snapshot IS NULL OR end_snapshot > ?)",
+            [new_snap, table_id, snapshot_id, snapshot_id],
+        )
+
+    def drop_table(
+        self,
+        table_name: str,
+        *,
+        schema_name: str = "main",
+    ) -> None:
+        """Drop a table from the catalog.
+
+        Sets ``end_snapshot`` on the table row, all its columns, and all
+        its active data/delete files. Table stats are left as-is
+        (matching DuckDB behaviour).
+        """
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        table_id = self._table_exists(table_name, schema_name, snap_id)
+        if table_id is None:
+            msg = f"Table '{schema_name}.{table_name}' not found"
+            raise ValueError(msg)
+
+        new_schema_ver = schema_ver + 1
+
+        # Create snapshot
+        new_snap = self._create_snapshot(new_schema_ver, next_cat_id, next_file_id)
+
+        # End the table row
+        con.execute(
+            "UPDATE ducklake_table SET end_snapshot = ? "
+            "WHERE table_id = ? AND end_snapshot IS NULL",
+            [new_snap, table_id],
+        )
+
+        # End all active columns
+        self._end_all_columns(table_id, snap_id, new_snap)
+
+        # End all active data files
+        self._end_all_data_files(table_id, snap_id, new_snap)
+
+        # End all active delete files
+        self._end_all_delete_files(table_id, snap_id, new_snap)
+
+        # Record schema version
+        con.execute(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version) "
+            "VALUES (?, ?)",
+            [new_snap, new_schema_ver],
+        )
+
+        # Record change
+        self._record_change(new_snap, f"dropped_table:{table_id}")
+
+        con.commit()
+
+    # ------------------------------------------------------------------
+    # CREATE SCHEMA
+    # ------------------------------------------------------------------
+
+    def _schema_exists(
+        self, schema_name: str, snapshot_id: int
+    ) -> int | None:
+        """Return schema_id if the schema exists at snapshot_id, else None."""
+        con = self._connect()
+        row = con.execute(
+            "SELECT schema_id FROM ducklake_schema "
+            "WHERE schema_name = ? AND begin_snapshot <= ? "
+            "AND (end_snapshot IS NULL OR end_snapshot > ?)",
+            [schema_name, snapshot_id, snapshot_id],
+        ).fetchone()
+        return row[0] if row is not None else None
+
+    def create_schema(
+        self,
+        schema_name: str,
+    ) -> int:
+        """Create a new schema in the catalog. Returns the new schema_id."""
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        if self._schema_exists(schema_name, snap_id) is not None:
+            msg = f"Schema '{schema_name}' already exists"
+            raise ValueError(msg)
+
+        schema_id = next_cat_id
+        new_next_cat_id = next_cat_id + 1
+        new_schema_ver = schema_ver + 1
+
+        # Create snapshot
+        new_snap = self._create_snapshot(new_schema_ver, new_next_cat_id, next_file_id)
+
+        # Insert schema
+        schema_uuid = str(uuid.uuid4())
+        schema_path = f"{schema_name}/"
+        con.execute(
+            "INSERT INTO ducklake_schema "
+            "(schema_id, schema_uuid, begin_snapshot, end_snapshot, "
+            "schema_name, path, path_is_relative) "
+            "VALUES (?, ?, ?, NULL, ?, ?, 1)",
+            [schema_id, schema_uuid, new_snap, schema_name, schema_path],
+        )
+
+        # Record schema version
+        con.execute(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version) "
+            "VALUES (?, ?)",
+            [new_snap, new_schema_ver],
+        )
+
+        # Record change
+        safe_schema = schema_name.replace('"', '""')
+        self._record_change(new_snap, f'created_schema:"{safe_schema}"')
+
+        con.commit()
+        return schema_id
+
+    # ------------------------------------------------------------------
+    # DROP SCHEMA
+    # ------------------------------------------------------------------
+
+    def _get_tables_in_schema(
+        self, schema_id: int, snapshot_id: int
+    ) -> list[tuple[int, str]]:
+        """Return [(table_id, table_name)] for active tables in a schema."""
+        con = self._connect()
+        rows = con.execute(
+            "SELECT table_id, table_name FROM ducklake_table "
+            "WHERE schema_id = ? AND begin_snapshot <= ? "
+            "AND (end_snapshot IS NULL OR end_snapshot > ?)",
+            [schema_id, snapshot_id, snapshot_id],
+        ).fetchall()
+        return [(r[0], r[1]) for r in rows]
+
+    def drop_schema(
+        self,
+        schema_name: str,
+        *,
+        cascade: bool = False,
+    ) -> None:
+        """Drop a schema from the catalog.
+
+        Parameters
+        ----------
+        schema_name
+            Name of the schema to drop.
+        cascade
+            If True, drop all tables in the schema first.
+            If False (default), raise if the schema contains tables.
+        """
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        schema_id = self._schema_exists(schema_name, snap_id)
+        if schema_id is None:
+            msg = f"Schema '{schema_name}' not found"
+            raise ValueError(msg)
+
+        tables = self._get_tables_in_schema(schema_id, snap_id)
+
+        if tables and not cascade:
+            table_names = ", ".join(f'"{t[1]}"' for t in tables)
+            msg = (
+                f"Cannot drop schema \"{schema_name}\" because there are "
+                f"entries that depend on it: {table_names}. "
+                f"Use cascade=True to drop all dependents."
+            )
+            raise ValueError(msg)
+
+        new_schema_ver = schema_ver + 1
+
+        # Create snapshot
+        new_snap = self._create_snapshot(new_schema_ver, next_cat_id, next_file_id)
+
+        # Build change description
+        changes: list[str] = []
+
+        # If cascade, drop all tables first
+        for table_id, _table_name in tables:
+            # End the table row
+            con.execute(
+                "UPDATE ducklake_table SET end_snapshot = ? "
+                "WHERE table_id = ? AND end_snapshot IS NULL",
+                [new_snap, table_id],
+            )
+            self._end_all_columns(table_id, snap_id, new_snap)
+            self._end_all_data_files(table_id, snap_id, new_snap)
+            self._end_all_delete_files(table_id, snap_id, new_snap)
+            changes.append(f"dropped_table:{table_id}")
+
+        # End the schema row
+        con.execute(
+            "UPDATE ducklake_schema SET end_snapshot = ? "
+            "WHERE schema_id = ? AND end_snapshot IS NULL",
+            [new_snap, schema_id],
+        )
+        changes.append(f"dropped_schema:{schema_id}")
+
+        # Record schema version
+        con.execute(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version) "
+            "VALUES (?, ?)",
+            [new_snap, new_schema_ver],
+        )
+
+        # Record change (DuckDB puts dropped_schema first when cascade)
+        # Re-order: schema first, then tables — matching DuckDB output
+        # Actually DuckDB does: dropped_schema:1,dropped_table:2 (schema first)
+        # Let's match that order
+        schema_changes = [c for c in changes if c.startswith("dropped_schema")]
+        table_changes = [c for c in changes if c.startswith("dropped_table")]
+        ordered = schema_changes + table_changes
+        self._record_change(new_snap, ",".join(ordered))
+
+        con.commit()
+
+    # ------------------------------------------------------------------
+    # RENAME TABLE
+    # ------------------------------------------------------------------
+
+    def rename_table(
+        self,
+        old_table_name: str,
+        new_table_name: str,
+        *,
+        schema_name: str = "main",
+    ) -> None:
+        """Rename a table in the catalog.
+
+        DuckLake tracks renames by ending the old table row and inserting
+        a new row with the same ``table_id`` and ``table_uuid`` but a
+        different name. The path stays the same (old directory).
+        """
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        table_id = self._table_exists(old_table_name, schema_name, snap_id)
+        if table_id is None:
+            msg = f"Table '{schema_name}.{old_table_name}' not found"
+            raise ValueError(msg)
+
+        if self._table_exists(new_table_name, schema_name, snap_id) is not None:
+            msg = f"Table '{schema_name}.{new_table_name}' already exists"
+            raise ValueError(msg)
+
+        # Get full table row details
+        row = con.execute(
+            "SELECT table_uuid, schema_id, path, path_is_relative "
+            "FROM ducklake_table "
+            "WHERE table_id = ? AND end_snapshot IS NULL",
+            [table_id],
+        ).fetchone()
+        table_uuid = row[0]
+        schema_id = row[1]
+        table_path = row[2]
+        path_is_relative = row[3]
+
+        new_schema_ver = schema_ver + 1
+
+        # Create snapshot
+        new_snap = self._create_snapshot(new_schema_ver, next_cat_id, next_file_id)
+
+        # End the old table row
+        con.execute(
+            "UPDATE ducklake_table SET end_snapshot = ? "
+            "WHERE table_id = ? AND end_snapshot IS NULL",
+            [new_snap, table_id],
+        )
+
+        # Insert new table row with same table_id/uuid but new name
+        # Path stays the same (pointing to old directory)
+        con.execute(
+            "INSERT INTO ducklake_table "
+            "(table_id, table_uuid, begin_snapshot, end_snapshot, schema_id, "
+            "table_name, path, path_is_relative) "
+            "VALUES (?, ?, ?, NULL, ?, ?, ?, ?)",
+            [table_id, table_uuid, new_snap, schema_id,
+             new_table_name, table_path, path_is_relative],
+        )
+
+        # Record schema version
+        con.execute(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version) "
+            "VALUES (?, ?)",
+            [new_snap, new_schema_ver],
+        )
+
+        # Record change (DuckDB uses created_table for renames)
+        safe_schema = schema_name.replace('"', '""')
+        safe_table = new_table_name.replace('"', '""')
+        self._record_change(
+            new_snap, f'created_table:"{safe_schema}"."{safe_table}"'
+        )
+
+        con.commit()
+
+    # ------------------------------------------------------------------
     # ALTER TABLE: DROP COLUMN
     # ------------------------------------------------------------------
 

--- a/tests/test_write_ddl.py
+++ b/tests/test_write_ddl.py
@@ -1,0 +1,952 @@
+"""Tests for ducklake-polars DDL operations (rename column, drop table,
+create/drop schema, rename table)."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import duckdb
+import polars as pl
+import pytest
+
+from ducklake_polars import (
+    alter_ducklake_rename_column,
+    create_ducklake_schema,
+    create_ducklake_table,
+    drop_ducklake_schema,
+    drop_ducklake_table,
+    read_ducklake,
+    rename_ducklake_table,
+    write_ducklake,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_catalog(tmp_path):
+    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
+    metadata_path = str(tmp_path / "ddl_test.ducklake")
+    data_path = str(tmp_path / "data")
+    os.makedirs(data_path, exist_ok=True)
+
+    con = duckdb.connect()
+    con.install_extension("ducklake")
+    con.load_extension("ducklake")
+    con.execute(
+        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+    )
+    con.close()
+    return metadata_path, data_path
+
+
+def _read_with_duckdb(metadata_path, data_path, table_name, schema_name="main"):
+    """Read a table with DuckDB's DuckLake extension."""
+    con = duckdb.connect()
+    con.install_extension("ducklake")
+    con.load_extension("ducklake")
+    con.execute(
+        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+    )
+    safe_schema = schema_name.replace('"', '""')
+    safe_table = table_name.replace('"', '""')
+    cursor = con.execute(f'SELECT * FROM ducklake."{safe_schema}"."{safe_table}"')
+    columns = [desc[0] for desc in cursor.description]
+    rows = cursor.fetchall()
+    con.close()
+    if not rows:
+        return pl.DataFrame({c: [] for c in columns})
+    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
+    return pl.DataFrame(data)
+
+
+# ===========================================================================
+# RENAME COLUMN
+# ===========================================================================
+
+
+class TestRenameColumn:
+    """Test ALTER TABLE RENAME COLUMN."""
+
+    def test_rename_column_basic(self, tmp_path):
+        """Rename a column and read back."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+
+        result = read_ducklake(metadata_path, "test").sort("a")
+        assert result.columns == ["a", "c"]
+        assert result["a"].to_list() == [1, 2, 3]
+        assert result["c"].to_list() == ["x", "y", "z"]
+
+    def test_rename_column_metadata_correct(self, tmp_path):
+        """Verify metadata: old row ended, new row inserted with same column_id."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1], "b": ["hello"]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        sv_before = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        # Get column_id of 'b'
+        col_b_row = con.execute(
+            "SELECT column_id FROM ducklake_column "
+            "WHERE column_name = 'b' AND end_snapshot IS NULL"
+        ).fetchone()
+        col_b_id = col_b_row[0]
+        con.close()
+
+        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+
+        con = sqlite3.connect(metadata_path)
+        # Schema version incremented
+        sv_after = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        assert sv_after == sv_before + 1
+
+        # Old column row has end_snapshot set
+        old_col = con.execute(
+            "SELECT end_snapshot FROM ducklake_column "
+            "WHERE column_name = 'b'"
+        ).fetchone()
+        assert old_col is not None
+        assert old_col[0] is not None
+
+        # New column row uses the same column_id
+        new_col = con.execute(
+            "SELECT column_id, column_name FROM ducklake_column "
+            "WHERE column_name = 'c' AND end_snapshot IS NULL"
+        ).fetchone()
+        assert new_col is not None
+        assert new_col[0] == col_b_id  # same column_id
+
+        # Changes recorded
+        change = con.execute(
+            "SELECT changes_made FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()
+        assert "altered_table" in change[0]
+
+        con.close()
+
+    def test_rename_column_then_insert(self, tmp_path):
+        """Insert data after renaming a column."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+
+        new_row = pl.DataFrame({"a": [3], "c": ["z"]})
+        write_ducklake(new_row, metadata_path, "test", mode="append")
+
+        result = read_ducklake(metadata_path, "test").sort("a")
+        assert result.columns == ["a", "c"]
+        assert result["a"].to_list() == [1, 2, 3]
+        assert result["c"].to_list() == ["x", "y", "z"]
+
+    def test_rename_column_time_travel(self, tmp_path):
+        """Time travel sees the old column name."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        snap_before = con.execute(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
+        ).fetchone()[0]
+        con.close()
+
+        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+
+        # Latest: column is 'c'
+        result = read_ducklake(metadata_path, "test")
+        assert "c" in result.columns
+        assert "b" not in result.columns
+
+        # Before rename: column is 'b'
+        result_old = read_ducklake(
+            metadata_path, "test", snapshot_version=snap_before
+        )
+        assert "b" in result_old.columns
+        assert "c" not in result_old.columns
+
+    def test_rename_column_nonexistent_raises(self, tmp_path):
+        """Renaming a column that doesn't exist raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        with pytest.raises(ValueError, match="not found"):
+            alter_ducklake_rename_column(
+                metadata_path, "test", "missing", "new"
+            )
+
+    def test_rename_column_duplicate_raises(self, tmp_path):
+        """Renaming to an existing column name raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1], "b": [2]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        with pytest.raises(ValueError, match="already exists"):
+            alter_ducklake_rename_column(metadata_path, "test", "b", "a")
+
+    def test_rename_column_nonexistent_table_raises(self, tmp_path):
+        """Renaming on a nonexistent table raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+
+        with pytest.raises(ValueError, match="not found"):
+            alter_ducklake_rename_column(
+                metadata_path, "missing", "a", "b"
+            )
+
+    def test_rename_column_duckdb_interop(self, tmp_path):
+        """DuckDB can read after polars renames a column."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+
+        pdf = _read_with_duckdb(metadata_path, data_path, "test").sort("a")
+        assert "c" in pdf.columns
+        assert "b" not in pdf.columns
+        assert pdf["a"].to_list() == [1, 2]
+        assert pdf["c"].to_list() == ["x", "y"]
+
+    def test_duckdb_rename_column_polars_reads(self, tmp_path):
+        """DuckDB renames a column, polars reads correctly."""
+        metadata_path = str(tmp_path / "test.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
+        con.execute("INSERT INTO ducklake.test VALUES (1, 'hello'), (2, 'world')")
+        con.execute("ALTER TABLE ducklake.test RENAME COLUMN b TO c")
+        con.close()
+
+        result = read_ducklake(metadata_path, "test").sort("a")
+        assert result.columns == ["a", "c"]
+        assert result["a"].to_list() == [1, 2]
+        assert result["c"].to_list() == ["hello", "world"]
+
+    def test_rename_column_multiple(self, tmp_path):
+        """Rename multiple columns sequentially."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1], "b": [2], "c": [3]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        alter_ducklake_rename_column(metadata_path, "test", "b", "bb")
+        alter_ducklake_rename_column(metadata_path, "test", "c", "cc")
+
+        result = read_ducklake(metadata_path, "test")
+        assert result.columns == ["a", "bb", "cc"]
+        assert result["a"].to_list() == [1]
+        assert result["bb"].to_list() == [2]
+        assert result["cc"].to_list() == [3]
+
+
+# ===========================================================================
+# DROP TABLE
+# ===========================================================================
+
+
+class TestDropTable:
+    """Test DROP TABLE."""
+
+    def test_drop_table_basic(self, tmp_path):
+        """Drop a table and verify it's no longer readable."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        drop_ducklake_table(metadata_path, "test")
+
+        with pytest.raises(ValueError, match="not found"):
+            read_ducklake(metadata_path, "test")
+
+    def test_drop_table_metadata_correct(self, tmp_path):
+        """Verify metadata: end_snapshot on table, columns, data files."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1], "b": ["hello"]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        sv_before = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        con.close()
+
+        drop_ducklake_table(metadata_path, "test")
+
+        con = sqlite3.connect(metadata_path)
+        # Schema version incremented
+        sv_after = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        assert sv_after == sv_before + 1
+
+        # Table has end_snapshot set
+        table_row = con.execute(
+            "SELECT end_snapshot FROM ducklake_table "
+            "WHERE table_name = 'test'"
+        ).fetchone()
+        assert table_row[0] is not None
+
+        # All columns have end_snapshot set
+        active_cols = con.execute(
+            "SELECT COUNT(*) FROM ducklake_column WHERE end_snapshot IS NULL"
+        ).fetchone()[0]
+        assert active_cols == 0
+
+        # All data files have end_snapshot set
+        active_files = con.execute(
+            "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
+        ).fetchone()[0]
+        assert active_files == 0
+
+        # Changes recorded
+        change = con.execute(
+            "SELECT changes_made FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()
+        assert "dropped_table" in change[0]
+
+        con.close()
+
+    def test_drop_table_with_delete_files(self, tmp_path):
+        """Drop a table that has delete files."""
+        from ducklake_polars import delete_ducklake
+
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+        delete_ducklake(metadata_path, "test", pl.col("a") == 1)
+
+        drop_ducklake_table(metadata_path, "test")
+
+        con = sqlite3.connect(metadata_path)
+        # Delete files should also be ended
+        active_deletes = con.execute(
+            "SELECT COUNT(*) FROM ducklake_delete_file WHERE end_snapshot IS NULL"
+        ).fetchone()[0]
+        assert active_deletes == 0
+        con.close()
+
+    def test_drop_table_time_travel(self, tmp_path):
+        """Time travel can read the table before it was dropped."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        snap_before = con.execute(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
+        ).fetchone()[0]
+        con.close()
+
+        drop_ducklake_table(metadata_path, "test")
+
+        # Latest: table is gone
+        with pytest.raises(ValueError, match="not found"):
+            read_ducklake(metadata_path, "test")
+
+        # Before drop: table exists
+        result = read_ducklake(
+            metadata_path, "test", snapshot_version=snap_before
+        )
+        assert result["a"].to_list() == [1, 2, 3]
+
+    def test_drop_table_nonexistent_raises(self, tmp_path):
+        """Dropping a nonexistent table raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+
+        with pytest.raises(ValueError, match="not found"):
+            drop_ducklake_table(metadata_path, "missing")
+
+    def test_drop_table_duckdb_interop(self, tmp_path):
+        """DuckDB confirms table is dropped."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2]})
+        write_ducklake(df, metadata_path, "test", mode="error")
+
+        drop_ducklake_table(metadata_path, "test")
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        with pytest.raises(duckdb.CatalogException):
+            con.execute("SELECT * FROM ducklake.test")
+        con.close()
+
+    def test_duckdb_drop_table_polars_reads(self, tmp_path):
+        """DuckDB drops a table, polars confirms it's gone."""
+        metadata_path = str(tmp_path / "test.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE TABLE ducklake.test (a INTEGER)")
+        con.execute("INSERT INTO ducklake.test VALUES (1)")
+        con.execute("DROP TABLE ducklake.test")
+        con.close()
+
+        with pytest.raises(ValueError, match="not found"):
+            read_ducklake(metadata_path, "test")
+
+    def test_drop_and_recreate_table(self, tmp_path):
+        """Drop a table and create a new one with the same name."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df1 = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df1, metadata_path, "test", mode="error")
+
+        drop_ducklake_table(metadata_path, "test")
+
+        df2 = pl.DataFrame({"x": ["hello", "world"]})
+        write_ducklake(df2, metadata_path, "test", mode="error")
+
+        result = read_ducklake(metadata_path, "test").sort("x")
+        assert result.columns == ["x"]
+        assert result["x"].to_list() == ["hello", "world"]
+
+
+# ===========================================================================
+# CREATE SCHEMA
+# ===========================================================================
+
+
+class TestCreateSchema:
+    """Test CREATE SCHEMA."""
+
+    def test_create_schema_basic(self, tmp_path):
+        """Create a new schema."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+
+        create_ducklake_schema(metadata_path, "myschema")
+
+        con = sqlite3.connect(metadata_path)
+        row = con.execute(
+            "SELECT schema_name, path FROM ducklake_schema "
+            "WHERE schema_name = 'myschema' AND end_snapshot IS NULL"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "myschema"
+        assert row[1] == "myschema/"
+        con.close()
+
+    def test_create_schema_metadata_correct(self, tmp_path):
+        """Verify metadata: snapshot, schema_versions, changes."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+
+        con = sqlite3.connect(metadata_path)
+        sv_before = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        con.close()
+
+        create_ducklake_schema(metadata_path, "myschema")
+
+        con = sqlite3.connect(metadata_path)
+        sv_after = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        assert sv_after == sv_before + 1
+
+        # Schema version recorded
+        sv_row = con.execute(
+            "SELECT schema_version FROM ducklake_schema_versions "
+            "ORDER BY begin_snapshot DESC LIMIT 1"
+        ).fetchone()
+        assert sv_row[0] == sv_after
+
+        # Changes recorded
+        change = con.execute(
+            "SELECT changes_made FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()
+        assert 'created_schema:"myschema"' in change[0]
+
+        con.close()
+
+    def test_create_schema_duplicate_raises(self, tmp_path):
+        """Creating a schema that already exists raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        with pytest.raises(ValueError, match="already exists"):
+            create_ducklake_schema(metadata_path, "myschema")
+
+    def test_create_schema_then_create_table(self, tmp_path):
+        """Create a schema, then a table in it."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+
+        result = read_ducklake(metadata_path, "test", schema="myschema").sort("a")
+        assert result["a"].to_list() == [1, 2, 3]
+
+    def test_create_schema_duckdb_interop(self, tmp_path):
+        """DuckDB can see a schema created by polars."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        # Create a table in the schema and write data
+        df = pl.DataFrame({"a": [42]})
+        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+
+        pdf = _read_with_duckdb(metadata_path, data_path, "test", "myschema")
+        assert pdf["a"].to_list() == [42]
+
+    def test_duckdb_create_schema_polars_uses(self, tmp_path):
+        """DuckDB creates a schema, polars creates a table in it."""
+        metadata_path = str(tmp_path / "test.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE SCHEMA ducklake.myschema")
+        con.close()
+
+        df = pl.DataFrame({"a": [10, 20]})
+        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+
+        result = read_ducklake(metadata_path, "test", schema="myschema").sort("a")
+        assert result["a"].to_list() == [10, 20]
+
+    def test_create_multiple_schemas(self, tmp_path):
+        """Create multiple schemas."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "s1")
+        create_ducklake_schema(metadata_path, "s2")
+        create_ducklake_schema(metadata_path, "s3")
+
+        con = sqlite3.connect(metadata_path)
+        count = con.execute(
+            "SELECT COUNT(*) FROM ducklake_schema WHERE end_snapshot IS NULL"
+        ).fetchone()[0]
+        # main + s1 + s2 + s3
+        assert count == 4
+
+        names = [
+            r[0]
+            for r in con.execute(
+                "SELECT schema_name FROM ducklake_schema "
+                "WHERE end_snapshot IS NULL ORDER BY schema_id"
+            ).fetchall()
+        ]
+        assert names == ["main", "s1", "s2", "s3"]
+        con.close()
+
+
+# ===========================================================================
+# DROP SCHEMA
+# ===========================================================================
+
+
+class TestDropSchema:
+    """Test DROP SCHEMA."""
+
+    def test_drop_schema_empty(self, tmp_path):
+        """Drop an empty schema."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        drop_ducklake_schema(metadata_path, "myschema")
+
+        con = sqlite3.connect(metadata_path)
+        row = con.execute(
+            "SELECT end_snapshot FROM ducklake_schema "
+            "WHERE schema_name = 'myschema'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] is not None  # end_snapshot is set
+        con.close()
+
+    def test_drop_schema_metadata_correct(self, tmp_path):
+        """Verify metadata: snapshot, schema_versions, changes."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        con = sqlite3.connect(metadata_path)
+        sv_before = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        con.close()
+
+        drop_ducklake_schema(metadata_path, "myschema")
+
+        con = sqlite3.connect(metadata_path)
+        sv_after = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        assert sv_after == sv_before + 1
+
+        change = con.execute(
+            "SELECT changes_made FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()
+        assert "dropped_schema" in change[0]
+        con.close()
+
+    def test_drop_schema_with_tables_no_cascade_raises(self, tmp_path):
+        """Dropping a schema with tables without cascade raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        df = pl.DataFrame({"a": [1]})
+        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+
+        with pytest.raises(ValueError, match="entries that depend on it"):
+            drop_ducklake_schema(metadata_path, "myschema")
+
+    def test_drop_schema_cascade(self, tmp_path):
+        """Drop a schema with tables using cascade."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        df = pl.DataFrame({"a": [1, 2]})
+        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+
+        drop_ducklake_schema(metadata_path, "myschema", cascade=True)
+
+        # Schema is gone
+        con = sqlite3.connect(metadata_path)
+        row = con.execute(
+            "SELECT end_snapshot FROM ducklake_schema "
+            "WHERE schema_name = 'myschema'"
+        ).fetchone()
+        assert row[0] is not None
+
+        # Table is gone
+        active_tables = con.execute(
+            "SELECT COUNT(*) FROM ducklake_table WHERE end_snapshot IS NULL"
+        ).fetchone()[0]
+        assert active_tables == 0
+
+        # Changes recorded
+        change = con.execute(
+            "SELECT changes_made FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()
+        assert "dropped_schema" in change[0]
+        assert "dropped_table" in change[0]
+        con.close()
+
+    def test_drop_schema_nonexistent_raises(self, tmp_path):
+        """Dropping a nonexistent schema raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+
+        with pytest.raises(ValueError, match="not found"):
+            drop_ducklake_schema(metadata_path, "missing")
+
+    def test_drop_schema_duckdb_interop(self, tmp_path):
+        """DuckDB confirms dropped schema."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+
+        drop_ducklake_schema(metadata_path, "myschema")
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        with pytest.raises((duckdb.CatalogException, duckdb.BinderException)):
+            con.execute("CREATE TABLE ducklake.myschema.test (a INTEGER)")
+        con.close()
+
+    def test_duckdb_drop_schema_polars_confirms(self, tmp_path):
+        """DuckDB drops a schema, polars can no longer use it."""
+        metadata_path = str(tmp_path / "test.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE SCHEMA ducklake.myschema")
+        con.execute("DROP SCHEMA ducklake.myschema")
+        con.close()
+
+        # Can't create a table in a dropped schema
+        with pytest.raises(ValueError, match="not found"):
+            create_ducklake_table(
+                metadata_path, "test",
+                {"a": pl.Int64()},
+                schema="myschema",
+            )
+
+    def test_drop_schema_cascade_duckdb_interop(self, tmp_path):
+        """DuckDB can read table data from time travel after cascade drop."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        create_ducklake_schema(metadata_path, "myschema")
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        snap_before = con.execute(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
+        ).fetchone()[0]
+        con.close()
+
+        drop_ducklake_schema(metadata_path, "myschema", cascade=True)
+
+        # Time travel works
+        result = read_ducklake(
+            metadata_path, "test",
+            schema="myschema", snapshot_version=snap_before,
+        ).sort("a")
+        assert result["a"].to_list() == [1, 2, 3]
+
+
+# ===========================================================================
+# RENAME TABLE
+# ===========================================================================
+
+
+class TestRenameTable:
+    """Test RENAME TABLE."""
+
+    def test_rename_table_basic(self, tmp_path):
+        """Rename a table and read back by new name."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, metadata_path, "t1", mode="error")
+
+        rename_ducklake_table(metadata_path, "t1", "t2")
+
+        result = read_ducklake(metadata_path, "t2").sort("a")
+        assert result["a"].to_list() == [1, 2, 3]
+
+        # Old name should be gone
+        with pytest.raises(ValueError, match="not found"):
+            read_ducklake(metadata_path, "t1")
+
+    def test_rename_table_metadata_correct(self, tmp_path):
+        """Verify metadata: old row ended, new row with same table_id."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1]})
+        write_ducklake(df, metadata_path, "t1", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        sv_before = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        old_table = con.execute(
+            "SELECT table_id, table_uuid, path FROM ducklake_table "
+            "WHERE table_name = 't1' AND end_snapshot IS NULL"
+        ).fetchone()
+        old_table_id = old_table[0]
+        old_table_uuid = old_table[1]
+        old_path = old_table[2]
+        con.close()
+
+        rename_ducklake_table(metadata_path, "t1", "t2")
+
+        con = sqlite3.connect(metadata_path)
+        # Schema version incremented
+        sv_after = con.execute(
+            "SELECT schema_version FROM ducklake_snapshot "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        ).fetchone()[0]
+        assert sv_after == sv_before + 1
+
+        # Old table row ended
+        old_end = con.execute(
+            "SELECT end_snapshot FROM ducklake_table "
+            "WHERE table_name = 't1'"
+        ).fetchone()
+        assert old_end[0] is not None
+
+        # New row has same table_id, table_uuid, and path
+        new_table = con.execute(
+            "SELECT table_id, table_uuid, path FROM ducklake_table "
+            "WHERE table_name = 't2' AND end_snapshot IS NULL"
+        ).fetchone()
+        assert new_table[0] == old_table_id
+        assert new_table[1] == old_table_uuid
+        assert new_table[2] == old_path  # path doesn't change
+
+        # Columns unchanged
+        cols = con.execute(
+            "SELECT COUNT(*) FROM ducklake_column "
+            "WHERE table_id = ? AND end_snapshot IS NULL",
+            [old_table_id],
+        ).fetchone()[0]
+        assert cols > 0
+
+        # Data files unchanged
+        files = con.execute(
+            "SELECT COUNT(*) FROM ducklake_data_file "
+            "WHERE table_id = ? AND end_snapshot IS NULL",
+            [old_table_id],
+        ).fetchone()[0]
+        assert files > 0
+
+        con.close()
+
+    def test_rename_table_then_insert(self, tmp_path):
+        """Insert data after renaming a table."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2]})
+        write_ducklake(df, metadata_path, "t1", mode="error")
+
+        rename_ducklake_table(metadata_path, "t1", "t2")
+
+        new_row = pl.DataFrame({"a": [3]})
+        write_ducklake(new_row, metadata_path, "t2", mode="append")
+
+        result = read_ducklake(metadata_path, "t2").sort("a")
+        assert result["a"].to_list() == [1, 2, 3]
+
+    def test_rename_table_time_travel(self, tmp_path):
+        """Time travel sees the old table name."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2]})
+        write_ducklake(df, metadata_path, "t1", mode="error")
+
+        con = sqlite3.connect(metadata_path)
+        snap_before = con.execute(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
+        ).fetchone()[0]
+        con.close()
+
+        rename_ducklake_table(metadata_path, "t1", "t2")
+
+        # Before rename: old name works
+        result_old = read_ducklake(
+            metadata_path, "t1", snapshot_version=snap_before
+        ).sort("a")
+        assert result_old["a"].to_list() == [1, 2]
+
+    def test_rename_table_nonexistent_raises(self, tmp_path):
+        """Renaming a nonexistent table raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+
+        with pytest.raises(ValueError, match="not found"):
+            rename_ducklake_table(metadata_path, "missing", "new")
+
+    def test_rename_table_duplicate_raises(self, tmp_path):
+        """Renaming to an existing table name raises."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1]})
+        write_ducklake(df, metadata_path, "t1", mode="error")
+        write_ducklake(df, metadata_path, "t2", mode="error")
+
+        with pytest.raises(ValueError, match="already exists"):
+            rename_ducklake_table(metadata_path, "t1", "t2")
+
+    def test_rename_table_duckdb_interop(self, tmp_path):
+        """DuckDB can read a table renamed by polars."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df = pl.DataFrame({"a": [1, 2]})
+        write_ducklake(df, metadata_path, "t1", mode="error")
+
+        rename_ducklake_table(metadata_path, "t1", "t2")
+
+        pdf = _read_with_duckdb(metadata_path, data_path, "t2").sort("a")
+        assert pdf["a"].to_list() == [1, 2]
+
+        # Old name should fail
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        with pytest.raises(duckdb.CatalogException):
+            con.execute("SELECT * FROM ducklake.t1")
+        con.close()
+
+    def test_duckdb_rename_table_polars_reads(self, tmp_path):
+        """DuckDB renames a table, polars reads by new name."""
+        metadata_path = str(tmp_path / "test.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
+            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE TABLE ducklake.t1 (a INTEGER)")
+        con.execute("INSERT INTO ducklake.t1 VALUES (1), (2)")
+        con.execute("ALTER TABLE ducklake.t1 RENAME TO t2")
+        con.close()
+
+        result = read_ducklake(metadata_path, "t2").sort("a")
+        assert result["a"].to_list() == [1, 2]
+
+        with pytest.raises(ValueError, match="not found"):
+            read_ducklake(metadata_path, "t1")
+
+    def test_rename_table_then_create_with_old_name(self, tmp_path):
+        """Rename a table, then create a new table with the old name."""
+        metadata_path, data_path = _make_catalog(tmp_path)
+        df1 = pl.DataFrame({"a": [1, 2]})
+        write_ducklake(df1, metadata_path, "t1", mode="error")
+
+        rename_ducklake_table(metadata_path, "t1", "t2")
+
+        df2 = pl.DataFrame({"x": ["hello"]})
+        write_ducklake(df2, metadata_path, "t1", mode="error")
+
+        # Both tables exist
+        r1 = read_ducklake(metadata_path, "t1")
+        assert r1.columns == ["x"]
+        assert r1["x"].to_list() == ["hello"]
+
+        r2 = read_ducklake(metadata_path, "t2").sort("a")
+        assert r2["a"].to_list() == [1, 2]


### PR DESCRIPTION
## PR 2: Remaining DDL Operations

### New API
- `alter_ducklake_rename_column(path, table, old_name, new_name)`
- `drop_ducklake_table(path, table, schema)`
- `create_ducklake_schema(path, schema_name)`
- `drop_ducklake_schema(path, schema_name)`
- `rename_ducklake_table(path, old_name, new_name, schema)`

### Approach
Each operation was reverse-engineered by running the equivalent DDL via DuckDB, inspecting the SQLite catalog metadata changes, then replicating exactly.

### Tests
- 42 new tests in `tests/test_write_ddl.py`
- DuckDB interop verified in both directions (polars writes/DuckDB reads + DuckDB writes/polars reads)
- Error cases, time travel, combined operations
- 471 total tests, all passing