### PR TITLE
feat: PostgreSQL write backend + parametrized tests

### DIFF
--- a/src/ducklake_polars/__init__.py
+++ b/src/ducklake_polars/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
     "create_ducklake_table",
     "delete_ducklake",
     "update_ducklake",
+    "merge_ducklake",
+    "create_table_as_ducklake",
     "alter_ducklake_add_column",
     "alter_ducklake_drop_column",
     "alter_ducklake_rename_column",
@@ -170,7 +172,7 @@ def write_ducklake(
         DataFrame to write.
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to write to.
     schema
@@ -251,7 +253,7 @@ def create_ducklake_table(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to create.
     polars_schema
@@ -295,7 +297,7 @@ def delete_ducklake(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to delete from.
     predicate
@@ -348,7 +350,7 @@ def update_ducklake(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to update.
     updates
@@ -383,6 +385,126 @@ def update_ducklake(
         return writer.update_data(updates, predicate, table, schema_name=schema)
 
 
+def merge_ducklake(
+    path: str | Path,
+    table: str,
+    source_df: pl.DataFrame,
+    on: str | list[str],
+    *,
+    when_matched_update: dict[str, object] | bool | None = None,
+    when_not_matched_insert: bool = True,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+) -> tuple[int, int]:
+    """
+    Merge a source DataFrame into an existing DuckLake table.
+
+    Matches rows on the *on* key columns, optionally updates matched
+    target rows, and optionally inserts unmatched source rows. Implemented
+    as delete + insert in a single snapshot.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Supports SQLite and PostgreSQL backends.
+    table
+        Name of the target table.
+    source_df
+        Source DataFrame to merge from.
+    on
+        Column name(s) to match on. Can be a single string or a list.
+    when_matched_update
+        - ``None``: matched target rows are left untouched.
+        - ``True``: replace matched target rows with source rows.
+        - ``dict``: update matched target rows with these values
+          (literal or ``pl.Expr``).
+    when_not_matched_insert
+        If True (default), source rows that have no match in the
+        target are inserted.
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+    data_inlining_row_limit
+        Maximum number of inlined rows.
+
+    Returns
+    -------
+    tuple[int, int]
+        ``(rows_updated, rows_inserted)``.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(
+        metadata_path,
+        data_path_override=dp,
+        data_inlining_row_limit=data_inlining_row_limit,
+    ) as writer:
+        return writer.merge_data(
+            source_df,
+            table,
+            on,
+            when_matched_update=when_matched_update,
+            when_not_matched_insert=when_not_matched_insert,
+            schema_name=schema,
+        )
+
+
+def create_table_as_ducklake(
+    df: pl.DataFrame,
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+) -> None:
+    """
+    Create a new table and insert data in a single snapshot.
+
+    Equivalent to ``CREATE TABLE ... AS SELECT ...`` — the table schema
+    is inferred from the DataFrame and the data is written atomically.
+
+    Parameters
+    ----------
+    df
+        DataFrame whose schema defines the new table and whose rows
+        are the initial data.
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Supports SQLite and PostgreSQL backends.
+    table
+        Name of the table to create.
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+    data_inlining_row_limit
+        Maximum number of rows to store inline in the metadata catalog.
+
+    Raises
+    ------
+    ValueError
+        If the table already exists.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(
+        metadata_path,
+        data_path_override=dp,
+        data_inlining_row_limit=data_inlining_row_limit,
+    ) as writer:
+        writer.create_table_with_data(table, df, schema_name=schema)
+
+
 def alter_ducklake_add_column(
     path: str | Path,
     table: str,
@@ -400,7 +522,7 @@ def alter_ducklake_add_column(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to alter.
     col_name
@@ -444,7 +566,7 @@ def alter_ducklake_drop_column(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to alter.
     col_name
@@ -484,7 +606,7 @@ def alter_ducklake_rename_column(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to alter.
     old_col_name
@@ -527,7 +649,7 @@ def drop_ducklake_table(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to drop.
     schema
@@ -562,7 +684,7 @@ def create_ducklake_schema(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     schema_name
         Name of the schema to create.
     data_path
@@ -596,7 +718,7 @@ def drop_ducklake_schema(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     schema_name
         Name of the schema to drop.
     cascade
@@ -634,7 +756,7 @@ def rename_ducklake_table(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     old_table
         Current name of the table.
     new_table
@@ -677,7 +799,7 @@ def alter_ducklake_set_partitioned_by(
     ----------
     path
         Path to the DuckLake metadata catalog file (.ducklake or .db).
-        Currently only SQLite backends are supported for writes.
+        Supports SQLite and PostgreSQL backends.
     table
         Name of the table to partition.
     columns

--- a/src/ducklake_polars/_backend.py
+++ b/src/ducklake_polars/_backend.py
@@ -55,6 +55,12 @@ class _PsycopgConnectionWrapper:
             self._cur.execute(sql, params)
         return self._cur
 
+    def commit(self) -> None:
+        self._con.commit()
+
+    def rollback(self) -> None:
+        self._con.rollback()
+
     def close(self) -> None:
         self._cur.close()
         self._con.close()
@@ -67,18 +73,31 @@ class PostgreSQLBackend:
     connection_string: str
     placeholder: str = "%s"
 
-    def connect(self) -> Any:
-        """Open a read-only PostgreSQL connection via psycopg2."""
+    def _import_psycopg2(self) -> Any:
+        """Import psycopg2, raising a clear error if not installed."""
         try:
             import psycopg2
+
+            return psycopg2
         except ImportError:
             msg = (
                 "psycopg2 is required for PostgreSQL catalog backends. "
                 "Install it with: pip install ducklake-polars[postgres]"
             )
             raise ImportError(msg) from None
+
+    def connect(self) -> Any:
+        """Open a read-only PostgreSQL connection via psycopg2."""
+        psycopg2 = self._import_psycopg2()
         con = psycopg2.connect(self.connection_string)
         con.set_session(readonly=True, autocommit=True)
+        return _PsycopgConnectionWrapper(con)
+
+    def connect_writable(self) -> Any:
+        """Open a read-write PostgreSQL connection via psycopg2."""
+        psycopg2 = self._import_psycopg2()
+        con = psycopg2.connect(self.connection_string)
+        # autocommit=False (default) — caller manages transactions via commit()
         return _PsycopgConnectionWrapper(con)
 
     def is_table_not_found(self, exc: BaseException) -> bool:

--- a/src/ducklake_polars/_writer.py
+++ b/src/ducklake_polars/_writer.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import polars as pl
 
-from ducklake_polars._backend import SQLiteBackend, create_backend
+from ducklake_polars._backend import PostgreSQLBackend, SQLiteBackend, create_backend
 from ducklake_polars._schema import polars_type_to_duckdb
 
 
@@ -42,6 +42,35 @@ def _read_parquet_footer_size(path: str) -> int:
         return footer_len
     except (OSError, struct.error):
         return 0
+
+
+class _PlaceholderConnection:
+    """
+    Wraps a database connection to translate ``?`` placeholders to ``%s``.
+
+    This allows the writer to use ``?`` consistently everywhere while
+    supporting both SQLite (``?``) and PostgreSQL (``%s``) backends.
+    """
+
+    __slots__ = ("_con", "_placeholder")
+
+    def __init__(self, con: Any, placeholder: str) -> None:
+        self._con = con
+        self._placeholder = placeholder
+
+    def execute(self, sql: str, params: Any = None) -> Any:
+        if self._placeholder != "?":
+            sql = sql.replace("?", self._placeholder)
+        if params is not None:
+            return self._con.execute(sql, params)
+        return self._con.execute(sql)
+
+    def commit(self) -> None:
+        if hasattr(self._con, "commit"):
+            self._con.commit()
+
+    def close(self) -> None:
+        self._con.close()
 
 
 def _stat_value_to_str(value: Any, dtype: pl.DataType) -> str | None:
@@ -76,11 +105,16 @@ class _ColumnDef:
 
 class DuckLakeCatalogWriter:
     """
-    Writes metadata to a DuckLake catalog (SQLite only).
+    Writes metadata to a DuckLake catalog (SQLite or PostgreSQL).
 
     Handles snapshot creation, table/column registration, Parquet file
     writing, and statistics computation. Produces catalogs fully
     interoperable with DuckDB's DuckLake extension.
+
+    The backend is auto-detected from the metadata path: PostgreSQL
+    connection strings (``postgresql://...``) use psycopg2; everything
+    else is treated as a SQLite file path. SQL placeholder differences
+    (``?`` vs ``%s``) are handled transparently.
     """
 
     def __init__(
@@ -91,9 +125,6 @@ class DuckLakeCatalogWriter:
         data_inlining_row_limit: int = 0,
     ) -> None:
         self._backend = create_backend(metadata_path)
-        if not isinstance(self._backend, SQLiteBackend):
-            msg = "Write support is currently limited to SQLite backends"
-            raise ValueError(msg)
         self._metadata_path = metadata_path
         self._data_path_override = data_path_override
         self._data_inlining_row_limit = data_inlining_row_limit
@@ -101,7 +132,8 @@ class DuckLakeCatalogWriter:
 
     def _connect(self) -> Any:
         if self._con is None:
-            self._con = self._backend.connect_writable()
+            raw = self._backend.connect_writable()
+            self._con = _PlaceholderConnection(raw, self._backend.placeholder)
         return self._con
 
     def close(self) -> None:
@@ -170,8 +202,8 @@ class DuckLakeCatalogWriter:
     # Data inlining helpers
     # ------------------------------------------------------------------
 
-    def _duckdb_type_to_sqlite_type(self, duckdb_type: str) -> str:
-        """Map a DuckDB column type to an appropriate SQLite storage type."""
+    def _duckdb_type_to_sql_type(self, duckdb_type: str) -> str:
+        """Map a DuckDB column type to an appropriate storage type for the backend."""
         t = duckdb_type.lower()
         if t in (
             "int8", "int16", "int32", "int64", "uint8", "uint16",
@@ -180,6 +212,8 @@ class DuckLakeCatalogWriter:
         ):
             return "BIGINT"
         if t in ("float32", "float64", "float", "double"):
+            if isinstance(self._backend, PostgreSQLBackend):
+                return "DOUBLE PRECISION"
             return "DOUBLE"
         return "VARCHAR"
 
@@ -247,7 +281,7 @@ class DuckLakeCatalogWriter:
         ]
         for _col_id, col_name, col_type, _parent in columns:
             safe_col = col_name.replace('"', '""')
-            sqlite_type = self._duckdb_type_to_sqlite_type(col_type)
+            sqlite_type = self._duckdb_type_to_sql_type(col_type)
             col_defs.append(f'"{safe_col}" {sqlite_type}')
 
         create_sql = f'CREATE TABLE IF NOT EXISTS "{safe}" ({", ".join(col_defs)})'
@@ -262,12 +296,14 @@ class DuckLakeCatalogWriter:
         )
         return tbl_name
 
-    def _serialize_value_for_sqlite(self, value: Any, col_type: str) -> Any:
-        """Convert a Python value to the appropriate SQLite storage format."""
+    def _serialize_value(self, value: Any, col_type: str) -> Any:
+        """Convert a Python value to an appropriate storage format for the backend."""
         if value is None:
             return None
         t = col_type.lower()
         if t == "boolean":
+            # Inlined data tables use BIGINT for boolean columns in both
+            # SQLite and PostgreSQL, so always store as 0/1 integer.
             return 1 if value else 0
         if t in ("date",):
             return str(value)
@@ -305,7 +341,7 @@ class DuckLakeCatalogWriter:
             row_vals: list[Any] = [row_id_start + i, new_snap, None]
             for j, col_name in enumerate(col_names):
                 row_vals.append(
-                    self._serialize_value_for_sqlite(row_tuple[j], col_types[col_name])
+                    self._serialize_value(row_tuple[j], col_types[col_name])
                 )
             con.execute(insert_sql, row_vals)
 
@@ -451,8 +487,8 @@ class DuckLakeCatalogWriter:
                 "INSERT INTO ducklake_name_mapping "
                 "(mapping_id, column_id, source_name, target_field_id, "
                 "parent_column, is_partition) "
-                "VALUES (?, ?, ?, ?, ?, 0)",
-                [mapping_id, col_id, col_name, col_id, parent_col],
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                [mapping_id, col_id, col_name, col_id, parent_col, False],
             )
         return mapping_id
 
@@ -620,8 +656,8 @@ class DuckLakeCatalogWriter:
             "INSERT INTO ducklake_table "
             "(table_id, table_uuid, begin_snapshot, end_snapshot, schema_id, "
             "table_name, path, path_is_relative) "
-            "VALUES (?, ?, ?, NULL, ?, ?, ?, 1)",
-            [table_id, table_uuid, new_snap, schema_id, table_name, table_path],
+            "VALUES (?, ?, ?, NULL, ?, ?, ?, ?)",
+            [table_id, table_uuid, new_snap, schema_id, table_name, table_path, True],
         )
 
         # Flatten schema and insert columns
@@ -641,7 +677,7 @@ class DuckLakeCatalogWriter:
                     cd.column_order,
                     cd.column_name,
                     cd.column_type,
-                    1 if cd.nulls_allowed else 0,
+                    cd.nulls_allowed,
                     cd.parent_column,
                 ],
             )
@@ -662,6 +698,157 @@ class DuckLakeCatalogWriter:
 
         con.commit()
         return table_id
+
+    def create_table_with_data(
+        self,
+        table_name: str,
+        df: pl.DataFrame,
+        *,
+        schema_name: str = "main",
+    ) -> int:
+        """
+        Create a new table and insert data in a single snapshot.
+
+        Returns the new snapshot ID.
+        """
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        # Check table doesn't exist
+        if self._table_exists(table_name, schema_name, snap_id) is not None:
+            msg = f"Table '{schema_name}.{table_name}' already exists"
+            raise ValueError(msg)
+
+        # Resolve schema
+        schema_id, schema_path, schema_path_rel = self._resolve_schema_info(
+            schema_name, snap_id
+        )
+
+        # Allocate IDs
+        table_id = next_cat_id
+        new_next_cat_id = next_cat_id + 1
+        new_schema_ver = schema_ver + 1
+
+        # Flatten schema
+        schema_dict = dict(df.schema)
+        col_defs = self._flatten_schema(schema_dict)
+        top_level_cols = [
+            (cd.column_id, cd.column_name, cd.column_type, cd.parent_column)
+            for cd in col_defs
+            if cd.parent_column is None
+        ]
+
+        table_path = f"{table_name}/"
+
+        # Determine data handling
+        has_data = not df.is_empty()
+        inline_data = (
+            has_data
+            and self._data_inlining_row_limit > 0
+            and len(df) <= self._data_inlining_row_limit
+        )
+
+        if has_data and not inline_data:
+            data_file_id = next_file_id
+            new_next_file_id = next_file_id + 1
+        else:
+            new_next_file_id = next_file_id
+
+        # Create single snapshot
+        new_snap = self._create_snapshot(
+            new_schema_ver, new_next_cat_id, new_next_file_id
+        )
+
+        # Insert table
+        table_uuid = str(uuid.uuid4())
+        con.execute(
+            "INSERT INTO ducklake_table "
+            "(table_id, table_uuid, begin_snapshot, end_snapshot, schema_id, "
+            "table_name, path, path_is_relative) "
+            "VALUES (?, ?, ?, NULL, ?, ?, ?, ?)",
+            [table_id, table_uuid, new_snap, schema_id, table_name, table_path, True],
+        )
+
+        # Insert columns
+        for cd in col_defs:
+            con.execute(
+                "INSERT INTO ducklake_column "
+                "(column_id, begin_snapshot, end_snapshot, table_id, column_order, "
+                "column_name, column_type, initial_default, default_value, "
+                "nulls_allowed, parent_column) "
+                "VALUES (?, ?, NULL, ?, ?, ?, ?, NULL, NULL, ?, ?)",
+                [
+                    cd.column_id,
+                    new_snap,
+                    table_id,
+                    cd.column_order,
+                    cd.column_name,
+                    cd.column_type,
+                    cd.nulls_allowed,
+                    cd.parent_column,
+                ],
+            )
+
+        # Record schema version
+        con.execute(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version) "
+            "VALUES (?, ?)",
+            [new_snap, new_schema_ver],
+        )
+
+        # Write data
+        if has_data:
+            if inline_data:
+                self._insert_inlined_rows(
+                    df, table_id, new_schema_ver, top_level_cols, new_snap, 0,
+                )
+                self._update_table_stats(table_id, len(df), 0)
+                col_stats = self._compute_file_column_stats(df, top_level_cols)
+                self._update_table_column_stats(
+                    table_id, top_level_cols, col_stats,
+                )
+            else:
+                # Build output directory
+                base = self.data_path
+                if schema_path_rel:
+                    base = os.path.join(base, schema_path)
+                else:
+                    base = schema_path
+                base = os.path.join(base, table_path)
+                os.makedirs(base, exist_ok=True)
+
+                file_name = f"ducklake-{_uuid7()}.parquet"
+                file_path = os.path.join(base, file_name)
+                df.write_parquet(file_path)
+
+                file_size = os.path.getsize(file_path)
+                footer_size = _read_parquet_footer_size(file_path)
+
+                mapping_id = self._register_name_mapping(table_id, top_level_cols)
+
+                self._register_data_file(
+                    data_file_id, table_id, new_snap, file_name,
+                    len(df), file_size, footer_size, 0,
+                    None, mapping_id,
+                )
+
+                col_stats = self._compute_file_column_stats(df, top_level_cols)
+                self._register_file_column_stats(
+                    data_file_id, table_id, col_stats,
+                )
+                self._update_table_stats(table_id, len(df), file_size)
+                self._update_table_column_stats(
+                    table_id, top_level_cols, col_stats,
+                )
+
+        safe_schema = schema_name.replace('"', '""')
+        safe_table = table_name.replace('"', '""')
+        self._record_change(
+            new_snap, f'created_table:"{safe_schema}"."{safe_table}"'
+        )
+
+        con.commit()
+        return new_snap
 
     # ------------------------------------------------------------------
     # INSERT DATA
@@ -763,7 +950,7 @@ class DuckLakeCatalogWriter:
             # NaN detection for float types
             nan_int = None
             if col_type in ("float32", "float64"):
-                nan_int = 1 if _contains_nan(series) else 0
+                nan_int = _contains_nan(series)
 
             results.append(
                 (col_id, col_name, value_count, null_count, min_val, max_val, nan_int)
@@ -836,12 +1023,13 @@ class DuckLakeCatalogWriter:
             "path, path_is_relative, file_format, record_count, file_size_bytes, "
             "footer_size, row_id_start, partition_id, encryption_key, "
             "partial_file_info, mapping_id) "
-            "VALUES (?, ?, ?, NULL, NULL, ?, 1, 'parquet', ?, ?, ?, ?, ?, NULL, NULL, ?)",
+            "VALUES (?, ?, ?, NULL, NULL, ?, ?, 'parquet', ?, ?, ?, ?, ?, NULL, NULL, ?)",
             [
                 data_file_id,
                 table_id,
                 new_snap,
                 rel_path,
+                True,
                 record_count,
                 file_size,
                 footer_size,
@@ -948,14 +1136,14 @@ class DuckLakeCatalogWriter:
                 [table_id, col_id],
             ).fetchone()
 
-            contains_null = 1 if null_count and null_count > 0 else 0
+            contains_null = bool(null_count and null_count > 0)
             contains_nan = nan_int if nan_int is not None else None
 
             if existing_col_stat is not None:
-                merged_null = 1 if (existing_col_stat[0] or contains_null) else 0
+                merged_null = bool(existing_col_stat[0] or contains_null)
                 merged_nan = None
                 if existing_col_stat[1] is not None or contains_nan is not None:
-                    merged_nan = 1 if (existing_col_stat[1] or (contains_nan or 0)) else 0
+                    merged_nan = bool(existing_col_stat[1] or contains_nan)
                 merged_min = self._merge_stat_value(
                     existing_col_stat[2], min_val, col_type, pick_min=True
                 )
@@ -1329,7 +1517,7 @@ class DuckLakeCatalogWriter:
             )
             col_stats = self._compute_file_column_stats(df, columns)
             for col_id, _col_name, _vc, null_count, min_val, max_val, nan_int in col_stats:
-                contains_null = 1 if null_count and null_count > 0 else 0
+                contains_null = bool(null_count and null_count > 0)
                 con.execute(
                     "INSERT INTO ducklake_table_column_stats "
                     "(table_id, column_id, contains_null, contains_nan, "
@@ -1383,7 +1571,7 @@ class DuckLakeCatalogWriter:
                 [table_id],
             )
             for col_id, _col_name, _vc, null_count, min_val, max_val, nan_int in col_stats:
-                contains_null = 1 if null_count and null_count > 0 else 0
+                contains_null = bool(null_count and null_count > 0)
                 con.execute(
                     "INSERT INTO ducklake_table_column_stats "
                     "(table_id, column_id, contains_null, contains_nan, "
@@ -1510,7 +1698,7 @@ class DuckLakeCatalogWriter:
         )
         full_col_stats = self._compute_file_column_stats(df, columns)
         for col_id, _col_name, _vc, null_count, min_val, max_val, nan_int in full_col_stats:
-            contains_null = 1 if null_count and null_count > 0 else 0
+            contains_null = bool(null_count and null_count > 0)
             con.execute(
                 "INSERT INTO ducklake_table_column_stats "
                 "(table_id, column_id, contains_null, contains_nan, "
@@ -1675,10 +1863,10 @@ class DuckLakeCatalogWriter:
                     "(delete_file_id, table_id, begin_snapshot, end_snapshot, "
                     "data_file_id, path, path_is_relative, format, delete_count, "
                     "file_size_bytes, footer_size, encryption_key) "
-                    "VALUES (?, ?, ?, NULL, ?, ?, 1, 'parquet', ?, ?, ?, NULL)",
+                    "VALUES (?, ?, ?, NULL, ?, ?, ?, 'parquet', ?, ?, ?, NULL)",
                     [
                         delete_file_id, table_id, new_snap, data_file_id,
-                        delete_file_name, len(positions),
+                        delete_file_name, True, len(positions),
                         delete_file_size, delete_footer_size,
                     ],
                 )
@@ -1893,10 +2081,10 @@ class DuckLakeCatalogWriter:
                 "(delete_file_id, table_id, begin_snapshot, end_snapshot, "
                 "data_file_id, path, path_is_relative, format, delete_count, "
                 "file_size_bytes, footer_size, encryption_key) "
-                "VALUES (?, ?, ?, NULL, ?, ?, 1, 'parquet', ?, ?, ?, NULL)",
+                "VALUES (?, ?, ?, NULL, ?, ?, ?, 'parquet', ?, ?, ?, NULL)",
                 [
                     delete_file_id, table_id, new_snap, data_file_id,
-                    delete_file_name, len(positions),
+                    delete_file_name, True, len(positions),
                     delete_file_size, delete_footer_size,
                 ],
             )
@@ -1988,7 +2176,403 @@ class DuckLakeCatalogWriter:
         return total_updated
 
     # ------------------------------------------------------------------
+    # MERGE (match on keys, delete matched + insert)
+    # ------------------------------------------------------------------
+
+    def _read_all_inlined_active_rows(
+        self,
+        table_id: int,
+        snapshot_id: int,
+        columns: list[tuple[int, str, str, int | None]],
+    ) -> pl.DataFrame | None:
+        """Read all active inlined rows as a DataFrame (no predicate filter)."""
+        con = self._connect()
+        try:
+            inlined_tables = con.execute(
+                "SELECT table_name FROM ducklake_inlined_data_tables "
+                "WHERE table_id = ?",
+                [table_id],
+            ).fetchall()
+        except Exception:
+            return None
+
+        col_names = [c[1] for c in columns]
+        all_dfs: list[pl.DataFrame] = []
+
+        for (tbl_name,) in inlined_tables:
+            safe = tbl_name.replace('"', '""')
+            cols_sql = ", ".join(
+                f'"{c.replace(chr(34), chr(34) + chr(34))}"' for c in col_names
+            )
+            try:
+                rows = con.execute(
+                    f'SELECT {cols_sql} FROM "{safe}" '
+                    f"WHERE ? >= begin_snapshot "
+                    f"AND (? < end_snapshot OR end_snapshot IS NULL)",
+                    [snapshot_id, snapshot_id],
+                ).fetchall()
+            except Exception:
+                continue
+
+            if rows:
+                data = {
+                    name: [r[i] for r in rows]
+                    for i, name in enumerate(col_names)
+                }
+                all_dfs.append(pl.DataFrame(data))
+
+        if not all_dfs:
+            return None
+        return pl.concat(all_dfs) if len(all_dfs) > 1 else all_dfs[0]
+
+    @staticmethod
+    def _build_key_match_predicate(
+        on: list[str],
+        matched_keys_df: pl.DataFrame,
+    ) -> pl.Expr:
+        """Build a Polars expression matching rows whose key columns are in *matched_keys_df*."""
+        if len(on) == 1:
+            return pl.col(on[0]).is_in(matched_keys_df[on[0]])
+
+        # Multiple key columns: OR of per-row AND conditions
+        conditions: list[pl.Expr] = []
+        for row in matched_keys_df.iter_rows(named=True):
+            row_cond: pl.Expr | None = None
+            for col in on:
+                eq = pl.col(col) == row[col]
+                row_cond = eq if row_cond is None else row_cond & eq
+            assert row_cond is not None
+            conditions.append(row_cond)
+
+        result = conditions[0]
+        for c in conditions[1:]:
+            result = result | c
+        return result
+
+    def merge_data(
+        self,
+        source_df: pl.DataFrame,
+        table_name: str,
+        on: str | list[str],
+        *,
+        when_matched_update: dict[str, Any] | bool | None = None,
+        when_not_matched_insert: bool = True,
+        schema_name: str = "main",
+    ) -> tuple[int, int]:
+        """
+        MERGE *source_df* into an existing table.
+
+        Matches rows on the *on* key columns, optionally updates matched
+        target rows, and optionally inserts unmatched source rows.
+        Implemented as delete + insert in a single snapshot.
+
+        Parameters
+        ----------
+        when_matched_update
+            - ``None``: matched target rows are left untouched.
+            - ``True``: replace matched target rows with source rows.
+            - ``dict``: update matched target rows with these values
+              (literal or ``pl.Expr``).
+        when_not_matched_insert
+            If True (default), source rows that have no match in the
+            target are inserted.
+
+        Returns ``(rows_updated, rows_inserted)``.
+        """
+        if isinstance(on, str):
+            on = [on]
+
+        con = self._connect()
+        snap_id, schema_ver, next_cat_id, next_file_id = self._get_latest_snapshot()
+
+        table_id, table_path, table_path_rel, schema_path, schema_path_rel = (
+            self._get_table_info(table_name, schema_name, snap_id)
+        )
+
+        columns = self._get_columns_for_table(table_id, snap_id)
+        col_names = [c[1] for c in columns]
+        data_files = self._get_active_data_files(table_id, snap_id)
+        inlined_count = self._get_inlined_active_row_count(table_id, snap_id)
+
+        # Unique source keys for matching
+        source_keys = source_df.select(on).unique()
+
+        # ----------------------------------------------------------
+        # Phase 1: find matched target rows in Parquet files
+        # ----------------------------------------------------------
+        pending_deletes: list[tuple[int, str, list[int]]] = []
+        matched_target_dfs: list[pl.DataFrame] = []
+        all_target_key_dfs: list[pl.DataFrame] = []
+
+        for data_file_id, rel_path, path_is_rel, _rc, _rid in data_files:
+            abs_path = self._resolve_file_path(
+                rel_path, path_is_rel,
+                table_path, table_path_rel,
+                schema_path, schema_path_rel,
+            )
+            file_df = pl.read_parquet(abs_path)
+            all_target_key_dfs.append(file_df.select(on))
+
+            if when_matched_update is not None:
+                file_df_idx = file_df.with_row_index("__merge_idx__")
+                matched = file_df_idx.join(source_keys, on=on, how="semi")
+                if len(matched) > 0:
+                    positions = sorted(matched["__merge_idx__"].to_list())
+                    pending_deletes.append((data_file_id, abs_path, positions))
+                    matched_target_dfs.append(matched.drop("__merge_idx__"))
+
+        # ----------------------------------------------------------
+        # Phase 2: find matched target rows in inlined data
+        # ----------------------------------------------------------
+        inlined_matched_df: pl.DataFrame | None = None
+        if inlined_count > 0:
+            inlined_df = self._read_all_inlined_active_rows(
+                table_id, snap_id, columns,
+            )
+            if inlined_df is not None and len(inlined_df) > 0:
+                all_target_key_dfs.append(inlined_df.select(on))
+                if when_matched_update is not None:
+                    inlined_matched = inlined_df.join(
+                        source_keys, on=on, how="semi",
+                    )
+                    if len(inlined_matched) > 0:
+                        inlined_matched_df = inlined_matched
+                        matched_target_dfs.append(inlined_matched)
+
+        # ----------------------------------------------------------
+        # Phase 3: counts and early exit
+        # ----------------------------------------------------------
+        total_updated = sum(len(p) for _, _, p in pending_deletes)
+        if inlined_matched_df is not None:
+            total_updated += len(inlined_matched_df)
+
+        # Find unmatched source rows
+        unmatched_source: pl.DataFrame
+        if when_not_matched_insert:
+            if all_target_key_dfs:
+                all_target_keys = pl.concat(all_target_key_dfs).unique()
+                unmatched_source = source_df.join(
+                    all_target_keys, on=on, how="anti",
+                )
+            else:
+                unmatched_source = source_df
+        else:
+            unmatched_source = source_df.clear()
+
+        total_inserted = len(unmatched_source)
+
+        if total_updated == 0 and total_inserted == 0:
+            return (0, 0)
+
+        # ----------------------------------------------------------
+        # Phase 4: build rows to insert
+        # ----------------------------------------------------------
+        rows_to_insert_parts: list[pl.DataFrame] = []
+
+        if when_matched_update is not None and matched_target_dfs:
+            all_matched = pl.concat(matched_target_dfs)
+            if when_matched_update is True:
+                # Replace with source rows
+                updated_rows = (
+                    all_matched.select(on)
+                    .join(source_df, on=on, how="inner")
+                    .select(col_names)
+                )
+                rows_to_insert_parts.append(updated_rows)
+            elif isinstance(when_matched_update, dict):
+                update_exprs: list[pl.Expr] = []
+                for col_name, value in when_matched_update.items():
+                    if isinstance(value, pl.Expr):
+                        update_exprs.append(value.alias(col_name))
+                    else:
+                        update_exprs.append(pl.lit(value).alias(col_name))
+                rows_to_insert_parts.append(
+                    all_matched.with_columns(update_exprs)
+                )
+
+        if total_inserted > 0:
+            rows_to_insert_parts.append(unmatched_source.select(col_names))
+
+        if not rows_to_insert_parts:
+            return (0, 0)
+
+        insert_df = (
+            pl.concat(rows_to_insert_parts)
+            if len(rows_to_insert_parts) > 1
+            else rows_to_insert_parts[0]
+        )
+
+        # ----------------------------------------------------------
+        # Phase 5: build output dir
+        # ----------------------------------------------------------
+        base = self.data_path
+        if schema_path_rel:
+            base = os.path.join(base, schema_path)
+        else:
+            base = schema_path
+        if table_path_rel:
+            base = os.path.join(base, table_path)
+        else:
+            base = table_path
+        os.makedirs(base, exist_ok=True)
+
+        # ----------------------------------------------------------
+        # Phase 6: allocate IDs and create snapshot
+        # ----------------------------------------------------------
+        n_delete_files = len(pending_deletes)
+        n_data_files = 1 if len(insert_df) > 0 else 0
+
+        # Check for partitioned table
+        part_id = self._get_active_partition(table_id, snap_id)
+        if part_id is not None and n_data_files > 0:
+            part_cols = self._get_partition_columns(part_id, table_id)
+            col_id_to_name: dict[int, str] = {c[0]: c[1] for c in columns}
+            part_col_names = [col_id_to_name[cid] for _, cid, _ in part_cols]
+            part_key_indices = [ki for ki, _, _ in part_cols]
+            groups = insert_df.group_by(part_col_names, maintain_order=True)
+            group_list: list[tuple[tuple, pl.DataFrame]] = []
+            for gk, gdf in groups:
+                if not isinstance(gk, tuple):
+                    gk = (gk,)
+                group_list.append((gk, gdf))
+            n_data_files = len(group_list)
+        else:
+            part_col_names = []
+            part_key_indices = []
+            group_list = []
+
+        first_data_file_id = next_file_id + n_delete_files
+        new_next_file_id = first_data_file_id + n_data_files
+
+        new_snap = self._create_snapshot(
+            schema_ver, next_cat_id, new_next_file_id,
+        )
+
+        # ----------------------------------------------------------
+        # Phase 7: write delete files for matched Parquet rows
+        # ----------------------------------------------------------
+        current_file_id = next_file_id
+        for data_file_id, abs_data_path, positions in pending_deletes:
+            delete_file_id = current_file_id
+            current_file_id += 1
+
+            delete_df = pl.DataFrame({
+                "file_path": [abs_data_path] * len(positions),
+                "pos": pl.Series(positions, dtype=pl.Int64),
+            })
+            delete_file_name = f"ducklake-{_uuid7()}-delete.parquet"
+            delete_file_path = os.path.join(base, delete_file_name)
+            delete_df.write_parquet(delete_file_path)
+
+            delete_file_size = os.path.getsize(delete_file_path)
+            delete_footer_size = _read_parquet_footer_size(delete_file_path)
+
+            con.execute(
+                "INSERT INTO ducklake_delete_file "
+                "(delete_file_id, table_id, begin_snapshot, end_snapshot, "
+                "data_file_id, path, path_is_relative, format, delete_count, "
+                "file_size_bytes, footer_size, encryption_key) "
+                "VALUES (?, ?, ?, NULL, ?, ?, ?, 'parquet', ?, ?, ?, NULL)",
+                [
+                    delete_file_id, table_id, new_snap, data_file_id,
+                    delete_file_name, True, len(positions),
+                    delete_file_size, delete_footer_size,
+                ],
+            )
+
+        # Delete matched inlined rows
+        if inlined_matched_df is not None and len(inlined_matched_df) > 0:
+            key_pred = self._build_key_match_predicate(
+                on, inlined_matched_df.select(on).unique(),
+            )
+            self._delete_inlined_rows(
+                table_id, key_pred, snap_id, new_snap, columns,
+            )
+
+        # ----------------------------------------------------------
+        # Phase 8: write new data file(s)
+        # ----------------------------------------------------------
+        existing_stats = self._get_table_stats(table_id)
+        row_id_start = existing_stats[1] if existing_stats else 0
+        mapping_id = self._register_name_mapping(table_id, columns)
+
+        if part_id is not None and group_list:
+            total_file_size = 0
+            current_data_file_id = first_data_file_id
+            current_row_id = row_id_start
+
+            for gk, gdf in group_list:
+                partition_values = [str(v) for v in gk]
+                hive_subdir = self._build_hive_path(
+                    part_col_names, partition_values,
+                )
+                partition_dir = os.path.join(base, hive_subdir)
+                os.makedirs(partition_dir, exist_ok=True)
+
+                file_name = f"ducklake-{_uuid7()}.parquet"
+                file_path = os.path.join(partition_dir, file_name)
+                gdf.write_parquet(file_path)
+
+                file_size = os.path.getsize(file_path)
+                footer_size = _read_parquet_footer_size(file_path)
+                rel_path = f"{hive_subdir}/{file_name}"
+
+                self._register_data_file(
+                    current_data_file_id, table_id, new_snap, rel_path,
+                    len(gdf), file_size, footer_size, current_row_id,
+                    part_id, mapping_id,
+                )
+                self._register_partition_values(
+                    current_data_file_id, table_id,
+                    part_key_indices, partition_values,
+                )
+                cs = self._compute_file_column_stats(gdf, columns)
+                self._register_file_column_stats(
+                    current_data_file_id, table_id, cs,
+                )
+
+                total_file_size += file_size
+                current_data_file_id += 1
+                current_row_id += len(gdf)
+
+            self._update_table_stats(table_id, len(insert_df), total_file_size)
+        elif len(insert_df) > 0:
+            file_name = f"ducklake-{_uuid7()}.parquet"
+            file_path = os.path.join(base, file_name)
+            insert_df.write_parquet(file_path)
+
+            file_size = os.path.getsize(file_path)
+            footer_size = _read_parquet_footer_size(file_path)
+
+            self._register_data_file(
+                first_data_file_id, table_id, new_snap, file_name,
+                len(insert_df), file_size, footer_size, row_id_start,
+                None, mapping_id,
+            )
+
+            col_stats = self._compute_file_column_stats(insert_df, columns)
+            self._register_file_column_stats(
+                first_data_file_id, table_id, col_stats,
+            )
+            self._update_table_stats(table_id, len(insert_df), file_size)
+
+        full_col_stats = self._compute_file_column_stats(insert_df, columns)
+        self._update_table_column_stats(table_id, columns, full_col_stats)
+
+        # Record changes
+        changes: list[str] = []
+        if total_updated > 0:
+            changes.append(f"deleted_from_table:{table_id}")
+        if total_updated > 0 or total_inserted > 0:
+            changes.append(f"inserted_into_table:{table_id}")
+        self._record_change(new_snap, ",".join(changes))
+
+        con.commit()
+        return (total_updated, total_inserted)
+
+    # ------------------------------------------------------------------
     # ALTER TABLE: ADD COLUMN
+    # ------------------------------------------------------------------
     # ------------------------------------------------------------------
 
     def _get_max_column_id(self, table_id: int) -> int:
@@ -2058,10 +2642,10 @@ class DuckLakeCatalogWriter:
             "(column_id, begin_snapshot, end_snapshot, table_id, column_order, "
             "column_name, column_type, initial_default, default_value, "
             "nulls_allowed, parent_column) "
-            "VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, 1, NULL)",
+            "VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, NULL)",
             [
                 new_col_id, new_snap, table_id, new_col_order,
-                column_name, duckdb_type, default_str, default_str,
+                column_name, duckdb_type, default_str, default_str, True,
             ],
         )
 
@@ -2283,8 +2867,8 @@ class DuckLakeCatalogWriter:
             "INSERT INTO ducklake_schema "
             "(schema_id, schema_uuid, begin_snapshot, end_snapshot, "
             "schema_name, path, path_is_relative) "
-            "VALUES (?, ?, ?, NULL, ?, ?, 1)",
-            [schema_id, schema_uuid, new_snap, schema_name, schema_path],
+            "VALUES (?, ?, ?, NULL, ?, ?, ?)",
+            [schema_id, schema_uuid, new_snap, schema_name, schema_path, True],
         )
 
         # Record schema version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import duckdb
+import polars as pl
 import pytest
 
 
@@ -200,3 +201,249 @@ def ducklake_catalog_inline(request, tmp_path):
     catalog.close()
     if backend == "postgres":
         catalog._cleanup_postgres_tables()
+
+
+# -----------------------------------------------------------------------
+# Write-test helpers
+# -----------------------------------------------------------------------
+
+
+@dataclass
+class WriteCatalogHelper:
+    """
+    Lightweight helper for write-path tests.
+
+    Provides ``metadata_path``, ``data_path``, ``backend`` and methods for
+    querying the metadata database and reading back with DuckDB. Created via
+    :func:`make_write_catalog` factory fixture.
+    """
+
+    metadata_path: str
+    data_path: str
+    backend: str  # "sqlite" or "postgres"
+    inline_limit: int = 0
+
+    # -- metadata queries ------------------------------------------------
+
+    def query_one(self, sql: str, params: list[Any] | None = None) -> Any:
+        """Execute SQL and return one row (fetchone)."""
+        if self.backend == "sqlite":
+            import sqlite3
+
+            con = sqlite3.connect(self.metadata_path)
+            try:
+                return con.execute(sql, params or []).fetchone()
+            finally:
+                con.close()
+        else:
+            import psycopg2
+
+            con = psycopg2.connect(self.metadata_path)
+            try:
+                con.autocommit = True
+                cur = con.cursor()
+                try:
+                    cur.execute(sql.replace("?", "%s"), params or [])
+                    return cur.fetchone()
+                finally:
+                    cur.close()
+            finally:
+                con.close()
+
+    def query_all(self, sql: str, params: list[Any] | None = None) -> list[Any]:
+        """Execute SQL and return all rows (fetchall)."""
+        if self.backend == "sqlite":
+            import sqlite3
+
+            con = sqlite3.connect(self.metadata_path)
+            try:
+                return con.execute(sql, params or []).fetchall()
+            finally:
+                con.close()
+        else:
+            import psycopg2
+
+            con = psycopg2.connect(self.metadata_path)
+            try:
+                con.autocommit = True
+                cur = con.cursor()
+                try:
+                    cur.execute(sql.replace("?", "%s"), params or [])
+                    return cur.fetchall()
+                finally:
+                    cur.close()
+            finally:
+                con.close()
+
+    # -- DuckDB interop --------------------------------------------------
+
+    def read_with_duckdb(
+        self, table_name: str, *, inline_limit: int | None = None
+    ) -> pl.DataFrame:
+        """Read a table back using DuckDB's DuckLake extension."""
+        limit = inline_limit if inline_limit is not None else self.inline_limit
+        if self.backend == "sqlite":
+            source = f"ducklake:sqlite:{self.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{self.metadata_path}"
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{self.data_path}', DATA_INLINING_ROW_LIMIT {limit})"
+        )
+        cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        con.close()
+        if not rows:
+            return pl.DataFrame({c: [] for c in columns})
+        data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
+        return pl.DataFrame(data)
+
+    def read_with_duckdb_schema(
+        self, table_name: str, schema_name: str, *, inline_limit: int | None = None
+    ) -> pl.DataFrame:
+        """Read a table in a non-default schema using DuckDB."""
+        limit = inline_limit if inline_limit is not None else self.inline_limit
+        if self.backend == "sqlite":
+            source = f"ducklake:sqlite:{self.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{self.metadata_path}"
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        con.execute(
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{self.data_path}', DATA_INLINING_ROW_LIMIT {limit})"
+        )
+        safe_schema = schema_name.replace('"', '""')
+        safe_table = table_name.replace('"', '""')
+        cursor = con.execute(
+            f'SELECT * FROM ducklake."{safe_schema}"."{safe_table}"'
+        )
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        con.close()
+        if not rows:
+            return pl.DataFrame({c: [] for c in columns})
+        data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
+        return pl.DataFrame(data)
+
+    # -- PostgreSQL cleanup -----------------------------------------------
+
+    def cleanup(self) -> None:
+        """Clean up PostgreSQL tables if applicable."""
+        if self.backend == "postgres":
+            import psycopg2
+
+            con = psycopg2.connect(self.metadata_path)
+            try:
+                con.autocommit = True
+                cur = con.cursor()
+                try:
+                    cur.execute(
+                        "SELECT tablename FROM pg_tables "
+                        "WHERE schemaname = 'public'"
+                    )
+                    tables = [row[0] for row in cur.fetchall()]
+                    for table in tables:
+                        safe = table.replace('"', '""')
+                        cur.execute(f'DROP TABLE IF EXISTS "{safe}" CASCADE')
+                finally:
+                    cur.close()
+            finally:
+                con.close()
+
+    # -- PRAGMA / table_info helper (SQLite PRAGMA → PG info_schema) -----
+
+    def get_table_columns(self, table_name: str) -> list[tuple[str, str]]:
+        """Return [(column_name, column_type)] for a raw SQL table.
+
+        Uses ``PRAGMA table_info`` on SQLite and ``information_schema``
+        on PostgreSQL.
+        """
+        if self.backend == "sqlite":
+            rows = self.query_all(f'PRAGMA table_info("{table_name}")')
+            return [(r[1], r[2]) for r in rows]
+        else:
+            rows = self.query_all(
+                "SELECT column_name, data_type "
+                "FROM information_schema.columns "
+                "WHERE table_name = ? ORDER BY ordinal_position",
+                [table_name],
+            )
+            return [(r[0], r[1]) for r in rows]
+
+
+def _create_write_catalog(
+    tmp_path: Any,
+    backend: str,
+    inline: bool = False,
+    inline_limit: int = 20,
+) -> WriteCatalogHelper:
+    """Create a DuckLake catalog via DuckDB and return a WriteCatalogHelper."""
+    if backend == "sqlite":
+        metadata_path = str(tmp_path / "write_test.ducklake")
+    else:
+        metadata_path = os.environ["DUCKLAKE_PG_DSN"]
+
+    data_path = str(tmp_path / "data")
+    os.makedirs(data_path, exist_ok=True)
+
+    helper = WriteCatalogHelper(
+        metadata_path=metadata_path,
+        data_path=data_path,
+        backend=backend,
+        inline_limit=inline_limit if inline else 0,
+    )
+
+    # Clean up first for PostgreSQL
+    helper.cleanup()
+
+    con = duckdb.connect()
+    con.install_extension("ducklake")
+    con.load_extension("ducklake")
+
+    if backend == "sqlite":
+        attach_source = f"ducklake:sqlite:{metadata_path}"
+    else:
+        attach_source = f"ducklake:postgres:{metadata_path}"
+
+    inline_opt = (
+        f", DATA_INLINING_ROW_LIMIT {inline_limit}"
+        if inline
+        else ", DATA_INLINING_ROW_LIMIT 0"
+    )
+    con.execute(
+        f"ATTACH '{attach_source}' AS ducklake "
+        f"(DATA_PATH '{data_path}'{inline_opt})"
+    )
+    con.close()
+
+    return helper
+
+
+@pytest.fixture(params=_get_backends())
+def make_write_catalog(request, tmp_path):
+    """
+    Factory fixture for write-path tests.
+
+    Yields a callable ``make(inline=False, inline_limit=20)`` that returns
+    a :class:`WriteCatalogHelper`. Parametrized over backends.
+    """
+    backend = request.param
+    created: list[WriteCatalogHelper] = []
+
+    def factory(inline: bool = False, inline_limit: int = 20) -> WriteCatalogHelper:
+        helper = _create_write_catalog(tmp_path, backend, inline, inline_limit)
+        created.append(helper)
+        return helper
+
+    yield factory
+
+    for h in created:
+        h.cleanup()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import sqlite3
 
 import duckdb
 import polars as pl
@@ -74,48 +73,6 @@ class TestPolarsTypeToDuckdb:
 
 
 # ---------------------------------------------------------------------------
-# Helpers: create DuckLake catalog fixtures for write tests
-# ---------------------------------------------------------------------------
-
-
-def _make_catalog(tmp_path, inline=False):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "write_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    inline_opt = "" if inline else ", DATA_INLINING_ROW_LIMIT 0"
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}'{inline_opt})"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name):
-    """Read a table with DuckDB's DuckLake extension (interop verification)."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
-# ---------------------------------------------------------------------------
 # Phase 5b: CREATE TABLE
 # ---------------------------------------------------------------------------
 
@@ -123,103 +80,98 @@ def _read_with_duckdb(metadata_path, data_path, table_name):
 class TestCreateTable:
     """Test create_ducklake_table."""
 
-    def test_create_simple_table(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_create_simple_table(self, make_write_catalog):
+        cat = make_write_catalog()
         schema = {"a": pl.Int32(), "b": pl.String(), "c": pl.Float64()}
 
-        create_ducklake_table(metadata_path, "test", schema)
+        create_ducklake_table(cat.metadata_path, "test", schema)
 
         # Verify table exists and is empty
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape == (0, 3)
         assert result.schema == {"a": pl.Int32, "b": pl.String, "c": pl.Float64}
 
-    def test_create_table_already_exists(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_create_table_already_exists(self, make_write_catalog):
+        cat = make_write_catalog()
         schema = {"a": pl.Int32()}
 
-        create_ducklake_table(metadata_path, "test", schema)
+        create_ducklake_table(cat.metadata_path, "test", schema)
 
         with pytest.raises(ValueError, match="already exists"):
-            create_ducklake_table(metadata_path, "test", schema)
+            create_ducklake_table(cat.metadata_path, "test", schema)
 
-    def test_create_table_with_polars_schema(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_create_table_with_polars_schema(self, make_write_catalog):
+        cat = make_write_catalog()
         schema = pl.Schema({"x": pl.Int64, "y": pl.Boolean})
 
-        create_ducklake_table(metadata_path, "test", schema)
+        create_ducklake_table(cat.metadata_path, "test", schema)
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.schema == {"x": pl.Int64, "y": pl.Boolean}
 
-    def test_create_table_metadata_correct(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_create_table_metadata_correct(self, make_write_catalog):
+        cat = make_write_catalog()
         schema = {"a": pl.Int32(), "b": pl.String()}
 
-        create_ducklake_table(metadata_path, "test", schema)
-
-        # Check metadata directly
-        con = sqlite3.connect(metadata_path)
+        create_ducklake_table(cat.metadata_path, "test", schema)
 
         # Table exists
-        row = con.execute(
+        row = cat.query_one(
             "SELECT table_name, path FROM ducklake_table WHERE table_name = 'test'"
-        ).fetchone()
+        )
         assert row is not None
         assert row[0] == "test"
         assert row[1] == "test/"
 
         # Columns exist
-        rows = con.execute(
+        rows = cat.query_all(
             "SELECT column_name, column_type FROM ducklake_column "
             "WHERE table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 'test') "
             "ORDER BY column_order"
-        ).fetchall()
+        )
         assert rows == [("a", "int32"), ("b", "varchar")]
 
         # Snapshot changes recorded
-        row = con.execute(
+        row = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert row is not None
         assert "created_table" in row[0]
         assert "test" in row[0]
 
         # Schema version incremented
-        versions = con.execute(
+        versions = cat.query_one(
             "SELECT schema_version FROM ducklake_schema_versions "
             "ORDER BY begin_snapshot DESC LIMIT 1"
-        ).fetchone()
+        )
         assert versions is not None
         assert versions[0] > 0
 
-        con.close()
-
-    def test_create_table_duckdb_interop(self, tmp_path):
+    def test_create_table_duckdb_interop(self, make_write_catalog):
         """DuckDB can read a table created by ducklake-polars."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         schema = {"a": pl.Int32(), "b": pl.String()}
 
-        create_ducklake_table(metadata_path, "test", schema)
+        create_ducklake_table(cat.metadata_path, "test", schema)
 
         # Write some data so DuckDB has something to verify
         df = pl.DataFrame({"a": [1, 2], "b": ["hello", "world"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
         # Read with DuckDB
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 2
         assert sorted(pdf["a"].to_list()) == [1, 2]
 
-    def test_create_multiple_tables(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_create_multiple_tables(self, make_write_catalog):
+        cat = make_write_catalog()
 
-        create_ducklake_table(metadata_path, "t1", {"a": pl.Int32()})
-        create_ducklake_table(metadata_path, "t2", {"x": pl.String(), "y": pl.Float64()})
+        create_ducklake_table(cat.metadata_path, "t1", {"a": pl.Int32()})
+        create_ducklake_table(cat.metadata_path, "t2", {"x": pl.String(), "y": pl.Float64()})
 
-        r1 = read_ducklake(metadata_path, "t1")
-        r2 = read_ducklake(metadata_path, "t2")
+        r1 = read_ducklake(cat.metadata_path, "t1")
+        r2 = read_ducklake(cat.metadata_path, "t2")
         assert r1.shape == (0, 1)
         assert r2.shape == (0, 2)
 
@@ -232,87 +184,87 @@ class TestCreateTable:
 class TestWriteDucklake:
     """Test write_ducklake with various modes."""
 
-    def test_write_mode_error_new_table(self, tmp_path):
+    def test_write_mode_error_new_table(self, make_write_catalog):
         """mode='error' creates a new table and inserts data."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert_frame_equal(result.sort("a"), df.sort("a"))
 
-    def test_write_mode_error_existing_table_raises(self, tmp_path):
+    def test_write_mode_error_existing_table_raises(self, make_write_catalog):
         """mode='error' raises if table already exists."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         with pytest.raises(ValueError, match="already exists"):
-            write_ducklake(df, metadata_path, "test", mode="error")
+            write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-    def test_write_mode_append_new_table(self, tmp_path):
+    def test_write_mode_append_new_table(self, make_write_catalog):
         """mode='append' creates table if it doesn't exist."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
 
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert_frame_equal(result.sort("a"), df.sort("a"))
 
-    def test_write_mode_append_existing(self, tmp_path):
+    def test_write_mode_append_existing(self, make_write_catalog):
         """mode='append' appends data to existing table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
         df2 = pl.DataFrame({"a": [3, 4], "b": ["z", "w"]})
 
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 4
         assert sorted(result["a"].to_list()) == [1, 2, 3, 4]
 
-    def test_write_mode_overwrite_new_table(self, tmp_path):
+    def test_write_mode_overwrite_new_table(self, make_write_catalog):
         """mode='overwrite' creates table if it doesn't exist."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [10, 20]})
 
-        write_ducklake(df, metadata_path, "test", mode="overwrite")
+        write_ducklake(df, cat.metadata_path, "test", mode="overwrite")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert_frame_equal(result.sort("a"), df.sort("a"))
 
-    def test_write_mode_overwrite_replaces(self, tmp_path):
+    def test_write_mode_overwrite_replaces(self, make_write_catalog):
         """mode='overwrite' replaces all existing data."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         df2 = pl.DataFrame({"a": [10, 20], "b": ["new1", "new2"]})
 
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="overwrite")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="overwrite")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 2
         assert sorted(result["a"].to_list()) == [10, 20]
 
-    def test_write_invalid_mode_raises(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_write_invalid_mode_raises(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
 
         with pytest.raises(ValueError, match="Invalid write mode"):
-            write_ducklake(df, metadata_path, "test", mode="invalid")
+            write_ducklake(df, cat.metadata_path, "test", mode="invalid")
 
-    def test_write_empty_df_mode_error(self, tmp_path):
+    def test_write_empty_df_mode_error(self, make_write_catalog):
         """mode='error' with empty DataFrame creates table but no data file."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": pl.Series([], dtype=pl.Int32), "b": pl.Series([], dtype=pl.String)})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape == (0, 2)
         assert result.schema == {"a": pl.Int32, "b": pl.String}
 
@@ -325,42 +277,42 @@ class TestWriteDucklake:
 class TestDuckDBInterop:
     """Verify that catalogs written by ducklake-polars are readable by DuckDB."""
 
-    def test_basic_interop(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_basic_interop(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["hello", "world", "test"]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 3
         assert sorted(pdf["a"].to_list()) == [1, 2, 3]
         assert sorted(pdf["b"].to_list()) == ["hello", "test", "world"]
 
-    def test_interop_multiple_inserts(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_interop_multiple_inserts(self, make_write_catalog):
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"x": [10, 20]})
         df2 = pl.DataFrame({"x": [30]})
 
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert sorted(pdf["x"].to_list()) == [10, 20, 30]
 
-    def test_interop_after_overwrite(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_interop_after_overwrite(self, make_write_catalog):
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"v": [1, 2, 3]})
         df2 = pl.DataFrame({"v": [99]})
 
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="overwrite")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="overwrite")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert pdf["v"].to_list() == [99]
 
-    def test_interop_various_types(self, tmp_path):
+    def test_interop_various_types(self, make_write_catalog):
         """Verify interop with various column types."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "int_col": pl.Series([1, 2], dtype=pl.Int32),
             "bigint_col": pl.Series([100, 200], dtype=pl.Int64),
@@ -369,43 +321,43 @@ class TestDuckDBInterop:
             "str_col": ["hello", "world"],
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 2
         assert sorted(pdf["int_col"].to_list()) == [1, 2]
         assert sorted(pdf["bigint_col"].to_list()) == [100, 200]
 
-    def test_interop_null_values(self, tmp_path):
+    def test_interop_null_values(self, make_write_catalog):
         """Verify interop with NULL values."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": pl.Series([1, None, 3], dtype=pl.Int32),
             "b": ["hello", None, "world"],
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 3
 
         # Verify null handling
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.sort("a", nulls_last=True)["a"].to_list() == [1, 3, None]
 
-    def test_interop_date_types(self, tmp_path):
+    def test_interop_date_types(self, make_write_catalog):
         """Verify interop with date/datetime types."""
         from datetime import date, datetime
 
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "d": [date(2025, 1, 1), date(2025, 6, 15)],
             "ts": [datetime(2025, 1, 1, 12, 0), datetime(2025, 6, 15, 18, 30)],
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape == (2, 2)
         assert result.sort("d")["d"].to_list() == [date(2025, 1, 1), date(2025, 6, 15)]
 
@@ -418,46 +370,46 @@ class TestDuckDBInterop:
 class TestRoundTrip:
     """Write and read with ducklake-polars (no DuckDB in the loop)."""
 
-    def test_roundtrip_basic(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_roundtrip_basic(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "id": [1, 2, 3],
             "name": ["alice", "bob", "charlie"],
             "value": [1.1, 2.2, 3.3],
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
-        result = read_ducklake(metadata_path, "test")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+        result = read_ducklake(cat.metadata_path, "test")
         assert_frame_equal(result.sort("id"), df.sort("id"))
 
-    def test_roundtrip_with_scan(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_roundtrip_with_scan(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"x": list(range(100))})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
-        result = scan_ducklake(metadata_path, "test").filter(pl.col("x") > 95).collect()
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+        result = scan_ducklake(cat.metadata_path, "test").filter(pl.col("x") > 95).collect()
         assert sorted(result["x"].to_list()) == [96, 97, 98, 99]
 
-    def test_roundtrip_append_then_read(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_roundtrip_append_then_read(self, make_write_catalog):
+        cat = make_write_catalog()
 
         for i in range(5):
             df = pl.DataFrame({"batch": [i], "val": [i * 10]})
-            write_ducklake(df, metadata_path, "test", mode="append")
+            write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 5
         assert sorted(result["batch"].to_list()) == [0, 1, 2, 3, 4]
 
-    def test_roundtrip_overwrite(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_roundtrip_overwrite(self, make_write_catalog):
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3]})
         df2 = pl.DataFrame({"a": [100]})
 
-        write_ducklake(df1, metadata_path, "test", mode="error")
-        write_ducklake(df2, metadata_path, "test", mode="overwrite")
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
+        write_ducklake(df2, cat.metadata_path, "test", mode="overwrite")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result["a"].to_list() == [100]
 
 
@@ -469,23 +421,21 @@ class TestRoundTrip:
 class TestColumnStats:
     """Verify column statistics are correctly computed and stored."""
 
-    def test_stats_registered(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_stats_registered(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": pl.Series([1, 5, 3], dtype=pl.Int32),
             "b": ["x", "z", "y"],
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         # Check file column stats directly
-        con = sqlite3.connect(metadata_path)
-        stats = con.execute(
+        stats = cat.query_all(
             "SELECT column_id, null_count, min_value, max_value "
             "FROM ducklake_file_column_stats "
             "ORDER BY column_id"
-        ).fetchall()
-        con.close()
+        )
 
         # Should have stats for both columns
         assert len(stats) >= 2
@@ -503,57 +453,51 @@ class TestColumnStats:
         assert b_stats[0][2] == "x"  # min
         assert b_stats[0][3] == "z"  # max
 
-    def test_stats_with_nulls(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_stats_with_nulls(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": pl.Series([1, None, 3], dtype=pl.Int32),
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        stats = con.execute(
+        stats = cat.query_one(
             "SELECT null_count, min_value, max_value "
             "FROM ducklake_file_column_stats WHERE column_id = 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert stats is not None
         assert stats[0] == 1  # null_count
         assert stats[1] == "1"  # min
         assert stats[2] == "3"  # max
 
-    def test_table_stats_updated(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_table_stats_updated(self, make_write_catalog):
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2]})
         df2 = pl.DataFrame({"a": [3]})
 
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT record_count, next_row_id FROM ducklake_table_stats"
-        ).fetchone()
-        con.close()
+        )
 
         assert row is not None
         assert row[0] == 3  # total records
         assert row[1] == 3  # next_row_id
 
-    def test_table_column_stats_aggregated(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_table_column_stats_aggregated(self, make_write_catalog):
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": pl.Series([1, 5], dtype=pl.Int32)})
         df2 = pl.DataFrame({"a": pl.Series([3, 10], dtype=pl.Int32)})
 
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT min_value, max_value FROM ducklake_table_column_stats WHERE column_id = 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert row is not None
         assert row[0] == "1"  # global min
@@ -568,100 +512,92 @@ class TestColumnStats:
 class TestWriteEdgeCases:
     """Test edge cases in the write path."""
 
-    def test_write_single_row(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_write_single_row(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [42]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result["a"].to_list() == [42]
 
-    def test_write_many_columns(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_write_many_columns(self, make_write_catalog):
+        cat = make_write_catalog()
         data = {f"col_{i}": [i] for i in range(20)}
         df = pl.DataFrame(data)
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape == (1, 20)
         for i in range(20):
             assert result[f"col_{i}"].to_list() == [i]
 
-    def test_write_boolean_stats(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_write_boolean_stats(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"flag": [True, False, True]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        stats = con.execute(
+        stats = cat.query_one(
             "SELECT min_value, max_value FROM ducklake_file_column_stats WHERE column_id = 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert stats is not None
         assert stats[0] == "false"
         assert stats[1] == "true"
 
-    def test_snapshot_progression(self, tmp_path):
+    def test_snapshot_progression(self, make_write_catalog):
         """Each write creates a new snapshot."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_count_1 = con.execute("SELECT COUNT(*) FROM ducklake_snapshot").fetchone()[0]
+        snap_count_1 = cat.query_one("SELECT COUNT(*) FROM ducklake_snapshot")[0]
 
-        write_ducklake(pl.DataFrame({"a": [2]}), metadata_path, "test", mode="append")
-        snap_count_2 = con.execute("SELECT COUNT(*) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        write_ducklake(pl.DataFrame({"a": [2]}), cat.metadata_path, "test", mode="append")
+        snap_count_2 = cat.query_one("SELECT COUNT(*) FROM ducklake_snapshot")[0]
 
         # mode='error' creates 2 snapshots (create_table + insert)
         # mode='append' creates 1 more snapshot
         assert snap_count_2 > snap_count_1
 
-    def test_parquet_file_naming(self, tmp_path):
+    def test_parquet_file_naming(self, make_write_catalog):
         """Written Parquet files follow ducklake-{uuid7}.parquet naming."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
 
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute("SELECT path FROM ducklake_data_file LIMIT 1").fetchone()
-        con.close()
+        row = cat.query_one("SELECT path FROM ducklake_data_file LIMIT 1")
 
         assert row is not None
         assert row[0].startswith("ducklake-")
         assert row[0].endswith(".parquet")
 
-    def test_time_travel_after_write(self, tmp_path):
+    def test_time_travel_after_write(self, make_write_catalog):
         """Time travel works correctly after writes."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         df1 = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df1, metadata_path, "test", mode="error")
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
 
         # Get snapshot after first write
-        con = sqlite3.connect(metadata_path)
-        snap_after_create = con.execute(
+        snap_after_create = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
         df2 = pl.DataFrame({"a": [3, 4]})
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
         # Read at latest: should have 4 rows
-        result_latest = read_ducklake(metadata_path, "test")
+        result_latest = read_ducklake(cat.metadata_path, "test")
         assert result_latest.shape[0] == 4
 
         # Read at snapshot after first write: should have 2 rows
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_after_create
+            cat.metadata_path, "test", snapshot_version=snap_after_create
         )
         assert result_old.shape[0] == 2
         assert sorted(result_old["a"].to_list()) == [1, 2]

--- a/tests/test_write_alter.py
+++ b/tests/test_write_alter.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import sqlite3
-
 import duckdb
 import polars as pl
 import pytest
@@ -20,47 +17,6 @@ from ducklake_polars import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_catalog(tmp_path):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "alter_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name):
-    """Read a table with DuckDB's DuckLake extension."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
-# ---------------------------------------------------------------------------
 # ADD COLUMN: basic operations
 # ---------------------------------------------------------------------------
 
@@ -68,166 +24,162 @@ def _read_with_duckdb(metadata_path, data_path, table_name):
 class TestAddColumn:
     """Test ALTER TABLE ADD COLUMN."""
 
-    def test_add_column_no_default(self, tmp_path):
+    def test_add_column_no_default(self, make_write_catalog):
         """Add a column without a default value."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.Float64())
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.Float64())
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "b"]
         assert result["a"].to_list() == [1, 2, 3]
         # Existing rows should have NULL for the new column
         assert result["b"].to_list() == [None, None, None]
 
-    def test_add_column_with_default(self, tmp_path):
+    def test_add_column_with_default(self, make_write_catalog):
         """Add a column with a default value (stored in metadata)."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         alter_ducklake_add_column(
-            metadata_path, "test", "d", pl.Int64(), default=42
+            cat.metadata_path, "test", "d", pl.Int64(), default=42
         )
 
         # Metadata stores the default
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT initial_default, default_value FROM ducklake_column "
             "WHERE column_name = 'd'"
-        ).fetchone()
-        con.close()
+        )
         assert row[0] == "42"
         assert row[1] == "42"
 
-    def test_add_column_then_insert(self, tmp_path):
+    def test_add_column_then_insert(self, make_write_catalog):
         """Insert data after adding a column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.String())
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.String())
 
         # Insert new row with both columns
         new_row = pl.DataFrame({"a": [3], "b": ["hello"]})
-        write_ducklake(new_row, metadata_path, "test", mode="append")
+        write_ducklake(new_row, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == [None, None, "hello"]
 
-    def test_add_column_metadata_correct(self, tmp_path):
+    def test_add_column_metadata_correct(self, make_write_catalog):
         """Verify metadata: schema_version, column row, schema_versions."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.Int32())
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.Int32())
 
-        con = sqlite3.connect(metadata_path)
         # Schema version incremented
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
         # New column row exists
-        col = con.execute(
+        col = cat.query_one(
             "SELECT column_name, column_type FROM ducklake_column "
             "WHERE column_name = 'b'"
-        ).fetchone()
+        )
         assert col is not None
         assert col[0] == "b"
         assert col[1] == "int32"
 
         # Changes recorded
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert change is not None
         assert "altered_table" in change[0]
 
         # Schema version recorded
-        sv_row = con.execute(
+        sv_row = cat.query_one(
             "SELECT schema_version FROM ducklake_schema_versions "
             "ORDER BY begin_snapshot DESC LIMIT 1"
-        ).fetchone()
+        )
         assert sv_row[0] == sv_after
 
-        con.close()
-
-    def test_add_multiple_columns(self, tmp_path):
+    def test_add_multiple_columns(self, make_write_catalog):
         """Add multiple columns sequentially."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.String())
-        alter_ducklake_add_column(metadata_path, "test", "c", pl.Float64())
-        alter_ducklake_add_column(metadata_path, "test", "d", pl.Boolean())
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.String())
+        alter_ducklake_add_column(cat.metadata_path, "test", "c", pl.Float64())
+        alter_ducklake_add_column(cat.metadata_path, "test", "d", pl.Boolean())
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.columns == ["a", "b", "c", "d"]
         assert result.schema == {
             "a": pl.Int64, "b": pl.String, "c": pl.Float64, "d": pl.Boolean,
         }
 
-    def test_add_column_duplicate_raises(self, tmp_path):
+    def test_add_column_duplicate_raises(self, make_write_catalog):
         """Adding a column that already exists raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         with pytest.raises(ValueError, match="already exists"):
-            alter_ducklake_add_column(metadata_path, "test", "a", pl.Int32())
+            alter_ducklake_add_column(cat.metadata_path, "test", "a", pl.Int32())
 
-    def test_add_column_nonexistent_table_raises(self, tmp_path):
+    def test_add_column_nonexistent_table_raises(self, make_write_catalog):
         """Adding a column to nonexistent table raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         with pytest.raises(ValueError, match="not found"):
             alter_ducklake_add_column(
-                metadata_path, "missing", "x", pl.Int32()
+                cat.metadata_path, "missing", "x", pl.Int32()
             )
 
-    def test_add_column_duckdb_interop(self, tmp_path):
+    def test_add_column_duckdb_interop(self, make_write_catalog):
         """DuckDB can read after polars adds a column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.String())
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.String())
 
         new_row = pl.DataFrame({"a": [3], "b": ["new"]})
-        write_ducklake(new_row, metadata_path, "test", mode="append")
+        write_ducklake(new_row, cat.metadata_path, "test", mode="append")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test").sort("a")
+        pdf = cat.read_with_duckdb("test").sort("a")
         assert pdf["a"].to_list() == [1, 2, 3]
         assert pdf["b"].to_list() == [None, None, "new"]
 
-    def test_duckdb_add_column_polars_reads(self, tmp_path):
+    def test_duckdb_add_column_polars_reads(self, make_write_catalog):
         """DuckDB adds a column, polars reads correctly."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            attach_source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            attach_source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{attach_source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER)")
         con.execute("INSERT INTO ducklake.test VALUES (1), (2)")
@@ -235,7 +187,7 @@ class TestAddColumn:
         con.execute("INSERT INTO ducklake.test VALUES (3, 'hello')")
         con.close()
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == [None, None, "hello"]
 
@@ -248,141 +200,137 @@ class TestAddColumn:
 class TestDropColumn:
     """Test ALTER TABLE DROP COLUMN."""
 
-    def test_drop_column(self, tmp_path):
+    def test_drop_column(self, make_write_catalog):
         """Drop a column from a table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [10, 20, 30]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_drop_column(metadata_path, "test", "c")
+        alter_ducklake_drop_column(cat.metadata_path, "test", "c")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "b"]
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["x", "y", "z"]
 
-    def test_drop_column_then_insert(self, tmp_path):
+    def test_drop_column_then_insert(self, make_write_catalog):
         """Insert data after dropping a column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"], "c": [10, 20]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_drop_column(metadata_path, "test", "c")
+        alter_ducklake_drop_column(cat.metadata_path, "test", "c")
 
         new_row = pl.DataFrame({"a": [3], "b": ["z"]})
-        write_ducklake(new_row, metadata_path, "test", mode="append")
+        write_ducklake(new_row, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "b"]
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["x", "y", "z"]
 
-    def test_drop_column_metadata_correct(self, tmp_path):
+    def test_drop_column_metadata_correct(self, make_write_catalog):
         """Verify metadata: end_snapshot set, schema_version bumped."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1], "b": ["x"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        alter_ducklake_drop_column(metadata_path, "test", "b")
+        alter_ducklake_drop_column(cat.metadata_path, "test", "b")
 
-        con = sqlite3.connect(metadata_path)
         # Schema version incremented
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
         # Column has end_snapshot set
-        col = con.execute(
+        col = cat.query_one(
             "SELECT end_snapshot FROM ducklake_column "
             "WHERE column_name = 'b'"
-        ).fetchone()
+        )
         assert col is not None
         assert col[0] is not None  # end_snapshot is set
 
         # Changes recorded
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert "altered_table" in change[0]
 
-        con.close()
-
-    def test_drop_column_nonexistent_raises(self, tmp_path):
+    def test_drop_column_nonexistent_raises(self, make_write_catalog):
         """Dropping a column that doesn't exist raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         with pytest.raises(ValueError, match="not found"):
-            alter_ducklake_drop_column(metadata_path, "test", "missing")
+            alter_ducklake_drop_column(cat.metadata_path, "test", "missing")
 
-    def test_drop_column_nonexistent_table_raises(self, tmp_path):
+    def test_drop_column_nonexistent_table_raises(self, make_write_catalog):
         """Dropping from a nonexistent table raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         with pytest.raises(ValueError, match="not found"):
-            alter_ducklake_drop_column(metadata_path, "missing", "col")
+            alter_ducklake_drop_column(cat.metadata_path, "missing", "col")
 
-    def test_drop_column_time_travel(self, tmp_path):
+    def test_drop_column_time_travel(self, make_write_catalog):
         """Time travel sees the column before it was dropped."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        snap_before = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        alter_ducklake_drop_column(metadata_path, "test", "b")
+        alter_ducklake_drop_column(cat.metadata_path, "test", "b")
 
         # Latest: column b is gone
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.columns == ["a"]
 
         # Before drop: column b is visible
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_before
+            cat.metadata_path, "test", snapshot_version=snap_before
         )
         assert result_old.columns == ["a", "b"]
         assert result_old.sort("a")["b"].to_list() == ["x", "y"]
 
-    def test_drop_column_duckdb_interop(self, tmp_path):
+    def test_drop_column_duckdb_interop(self, make_write_catalog):
         """DuckDB can read after polars drops a column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"], "c": [10, 20]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_drop_column(metadata_path, "test", "c")
+        alter_ducklake_drop_column(cat.metadata_path, "test", "c")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test").sort("a")
+        pdf = cat.read_with_duckdb("test").sort("a")
         assert "c" not in pdf.columns
         assert pdf["a"].to_list() == [1, 2]
         assert pdf["b"].to_list() == ["x", "y"]
 
-    def test_duckdb_drop_column_polars_reads(self, tmp_path):
+    def test_duckdb_drop_column_polars_reads(self, make_write_catalog):
         """DuckDB drops a column, polars reads correctly."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            attach_source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            attach_source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{attach_source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR, c FLOAT)")
         con.execute("INSERT INTO ducklake.test VALUES (1, 'hello', 1.0), (2, 'world', 2.0)")
@@ -390,7 +338,7 @@ class TestDropColumn:
         con.execute("INSERT INTO ducklake.test VALUES (3, 'new')")
         con.close()
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "b"]
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["hello", "world", "new"]
@@ -404,47 +352,47 @@ class TestDropColumn:
 class TestAddDropCombined:
     """Test combining ADD and DROP operations."""
 
-    def test_add_then_drop(self, tmp_path):
+    def test_add_then_drop(self, make_write_catalog):
         """Add a column then drop it."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.String())
-        alter_ducklake_drop_column(metadata_path, "test", "b")
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.String())
+        alter_ducklake_drop_column(cat.metadata_path, "test", "b")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.columns == ["a"]
 
-    def test_drop_then_add_same_name(self, tmp_path):
+    def test_drop_then_add_same_name(self, make_write_catalog):
         """Drop a column then add a new one with the same name."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_drop_column(metadata_path, "test", "b")
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.Int32())
+        alter_ducklake_drop_column(cat.metadata_path, "test", "b")
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.Int32())
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "b"]
         assert result["a"].to_list() == [1, 2]
         # Old data files have string "b", new column is Int32 → NULLs
         assert result["b"].to_list() == [None, None]
 
-    def test_add_drop_add_insert(self, tmp_path):
+    def test_add_drop_add_insert(self, make_write_catalog):
         """Add column, drop it, add another, then insert."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "temp", pl.String())
-        alter_ducklake_drop_column(metadata_path, "test", "temp")
-        alter_ducklake_add_column(metadata_path, "test", "final", pl.Float64())
+        alter_ducklake_add_column(cat.metadata_path, "test", "temp", pl.String())
+        alter_ducklake_drop_column(cat.metadata_path, "test", "temp")
+        alter_ducklake_add_column(cat.metadata_path, "test", "final", pl.Float64())
 
         new_row = pl.DataFrame({"a": [2], "final": [42.0]})
-        write_ducklake(new_row, metadata_path, "test", mode="append")
+        write_ducklake(new_row, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "final"]
         assert result["a"].to_list() == [1, 2]
         assert result["final"].to_list() == [None, 42.0]
@@ -458,41 +406,41 @@ class TestAddDropCombined:
 class TestAlterAndUpdate:
     """Test ALTER TABLE combined with UPDATE/DELETE."""
 
-    def test_add_column_then_update(self, tmp_path):
+    def test_add_column_then_update(self, make_write_catalog):
         """Add column, insert data, then update."""
         from ducklake_polars import update_ducklake
 
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_add_column(metadata_path, "test", "b", pl.String())
+        alter_ducklake_add_column(cat.metadata_path, "test", "b", pl.String())
 
         new_data = pl.DataFrame({"a": [4, 5], "b": ["four", "five"]})
-        write_ducklake(new_data, metadata_path, "test", mode="append")
+        write_ducklake(new_data, cat.metadata_path, "test", mode="append")
 
         update_ducklake(
-            metadata_path, "test", {"b": "updated"}, pl.col("a") >= 4
+            cat.metadata_path, "test", {"b": "updated"}, pl.col("a") >= 4
         )
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3, 4, 5]
         assert result["b"].to_list() == [None, None, None, "updated", "updated"]
 
-    def test_drop_column_then_update(self, tmp_path):
+    def test_drop_column_then_update(self, make_write_catalog):
         """Drop column, then update remaining columns."""
         from ducklake_polars import update_ducklake
 
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [10, 20, 30]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_drop_column(metadata_path, "test", "c")
+        alter_ducklake_drop_column(cat.metadata_path, "test", "c")
 
         update_ducklake(
-            metadata_path, "test", {"b": "NEW"}, pl.col("a") == 2
+            cat.metadata_path, "test", {"b": "NEW"}, pl.col("a") == 2
         )
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "b"]
         assert result["b"].to_list() == ["x", "NEW", "z"]

--- a/tests/test_write_ddl.py
+++ b/tests/test_write_ddl.py
@@ -3,9 +3,6 @@ create/drop schema, rename table)."""
 
 from __future__ import annotations
 
-import os
-import sqlite3
-
 import duckdb
 import polars as pl
 import pytest
@@ -22,49 +19,6 @@ from ducklake_polars import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_catalog(tmp_path):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "ddl_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name, schema_name="main"):
-    """Read a table with DuckDB's DuckLake extension."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    safe_schema = schema_name.replace('"', '""')
-    safe_table = table_name.replace('"', '""')
-    cursor = con.execute(f'SELECT * FROM ducklake."{safe_schema}"."{safe_table}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
 # ===========================================================================
 # RENAME COLUMN
 # ===========================================================================
@@ -73,191 +27,187 @@ def _read_with_duckdb(metadata_path, data_path, table_name, schema_name="main"):
 class TestRenameColumn:
     """Test ALTER TABLE RENAME COLUMN."""
 
-    def test_rename_column_basic(self, tmp_path):
+    def test_rename_column_basic(self, make_write_catalog):
         """Rename a column and read back."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "b", "c")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "c"]
         assert result["a"].to_list() == [1, 2, 3]
         assert result["c"].to_list() == ["x", "y", "z"]
 
-    def test_rename_column_metadata_correct(self, tmp_path):
+    def test_rename_column_metadata_correct(self, make_write_catalog):
         """Verify metadata: old row ended, new row inserted with same column_id."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1], "b": ["hello"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         # Get column_id of 'b'
-        col_b_row = con.execute(
+        col_b_row = cat.query_one(
             "SELECT column_id FROM ducklake_column "
             "WHERE column_name = 'b' AND end_snapshot IS NULL"
-        ).fetchone()
+        )
         col_b_id = col_b_row[0]
-        con.close()
 
-        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "b", "c")
 
-        con = sqlite3.connect(metadata_path)
         # Schema version incremented
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
         # Old column row has end_snapshot set
-        old_col = con.execute(
+        old_col = cat.query_one(
             "SELECT end_snapshot FROM ducklake_column "
             "WHERE column_name = 'b'"
-        ).fetchone()
+        )
         assert old_col is not None
         assert old_col[0] is not None
 
         # New column row uses the same column_id
-        new_col = con.execute(
+        new_col = cat.query_one(
             "SELECT column_id, column_name FROM ducklake_column "
             "WHERE column_name = 'c' AND end_snapshot IS NULL"
-        ).fetchone()
+        )
         assert new_col is not None
         assert new_col[0] == col_b_id  # same column_id
 
         # Changes recorded
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert "altered_table" in change[0]
 
-        con.close()
-
-    def test_rename_column_then_insert(self, tmp_path):
+    def test_rename_column_then_insert(self, make_write_catalog):
         """Insert data after renaming a column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "b", "c")
 
         new_row = pl.DataFrame({"a": [3], "c": ["z"]})
-        write_ducklake(new_row, metadata_path, "test", mode="append")
+        write_ducklake(new_row, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "c"]
         assert result["a"].to_list() == [1, 2, 3]
         assert result["c"].to_list() == ["x", "y", "z"]
 
-    def test_rename_column_time_travel(self, tmp_path):
+    def test_rename_column_time_travel(self, make_write_catalog):
         """Time travel sees the old column name."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        snap_before = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "b", "c")
 
         # Latest: column is 'c'
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert "c" in result.columns
         assert "b" not in result.columns
 
         # Before rename: column is 'b'
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_before
+            cat.metadata_path, "test", snapshot_version=snap_before
         )
         assert "b" in result_old.columns
         assert "c" not in result_old.columns
 
-    def test_rename_column_nonexistent_raises(self, tmp_path):
+    def test_rename_column_nonexistent_raises(self, make_write_catalog):
         """Renaming a column that doesn't exist raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         with pytest.raises(ValueError, match="not found"):
             alter_ducklake_rename_column(
-                metadata_path, "test", "missing", "new"
+                cat.metadata_path, "test", "missing", "new"
             )
 
-    def test_rename_column_duplicate_raises(self, tmp_path):
+    def test_rename_column_duplicate_raises(self, make_write_catalog):
         """Renaming to an existing column name raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1], "b": [2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         with pytest.raises(ValueError, match="already exists"):
-            alter_ducklake_rename_column(metadata_path, "test", "b", "a")
+            alter_ducklake_rename_column(cat.metadata_path, "test", "b", "a")
 
-    def test_rename_column_nonexistent_table_raises(self, tmp_path):
+    def test_rename_column_nonexistent_table_raises(self, make_write_catalog):
         """Renaming on a nonexistent table raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         with pytest.raises(ValueError, match="not found"):
             alter_ducklake_rename_column(
-                metadata_path, "missing", "a", "b"
+                cat.metadata_path, "missing", "a", "b"
             )
 
-    def test_rename_column_duckdb_interop(self, tmp_path):
+    def test_rename_column_duckdb_interop(self, make_write_catalog):
         """DuckDB can read after polars renames a column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_rename_column(metadata_path, "test", "b", "c")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "b", "c")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test").sort("a")
+        pdf = cat.read_with_duckdb("test").sort("a")
         assert "c" in pdf.columns
         assert "b" not in pdf.columns
         assert pdf["a"].to_list() == [1, 2]
         assert pdf["c"].to_list() == ["x", "y"]
 
-    def test_duckdb_rename_column_polars_reads(self, tmp_path):
+    def test_duckdb_rename_column_polars_reads(self, make_write_catalog):
         """DuckDB renames a column, polars reads correctly."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
         con.execute("INSERT INTO ducklake.test VALUES (1, 'hello'), (2, 'world')")
         con.execute("ALTER TABLE ducklake.test RENAME COLUMN b TO c")
         con.close()
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result.columns == ["a", "c"]
         assert result["a"].to_list() == [1, 2]
         assert result["c"].to_list() == ["hello", "world"]
 
-    def test_rename_column_multiple(self, tmp_path):
+    def test_rename_column_multiple(self, make_write_catalog):
         """Rename multiple columns sequentially."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1], "b": [2], "c": [3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_rename_column(metadata_path, "test", "b", "bb")
-        alter_ducklake_rename_column(metadata_path, "test", "c", "cc")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "b", "bb")
+        alter_ducklake_rename_column(cat.metadata_path, "test", "c", "cc")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.columns == ["a", "bb", "cc"]
         assert result["a"].to_list() == [1]
         assert result["bb"].to_list() == [2]
@@ -272,149 +222,148 @@ class TestRenameColumn:
 class TestDropTable:
     """Test DROP TABLE."""
 
-    def test_drop_table_basic(self, tmp_path):
+    def test_drop_table_basic(self, make_write_catalog):
         """Drop a table and verify it's no longer readable."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        drop_ducklake_table(metadata_path, "test")
+        drop_ducklake_table(cat.metadata_path, "test")
 
         with pytest.raises(ValueError, match="not found"):
-            read_ducklake(metadata_path, "test")
+            read_ducklake(cat.metadata_path, "test")
 
-    def test_drop_table_metadata_correct(self, tmp_path):
+    def test_drop_table_metadata_correct(self, make_write_catalog):
         """Verify metadata: end_snapshot on table, columns, data files."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1], "b": ["hello"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        drop_ducklake_table(metadata_path, "test")
+        drop_ducklake_table(cat.metadata_path, "test")
 
-        con = sqlite3.connect(metadata_path)
         # Schema version incremented
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
         # Table has end_snapshot set
-        table_row = con.execute(
+        table_row = cat.query_one(
             "SELECT end_snapshot FROM ducklake_table "
             "WHERE table_name = 'test'"
-        ).fetchone()
+        )
         assert table_row[0] is not None
 
         # All columns have end_snapshot set
-        active_cols = con.execute(
+        active_cols = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_column WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
+        )[0]
         assert active_cols == 0
 
         # All data files have end_snapshot set
-        active_files = con.execute(
+        active_files = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
+        )[0]
         assert active_files == 0
 
         # Changes recorded
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert "dropped_table" in change[0]
 
-        con.close()
-
-    def test_drop_table_with_delete_files(self, tmp_path):
+    def test_drop_table_with_delete_files(self, make_write_catalog):
         """Drop a table that has delete files."""
         from ducklake_polars import delete_ducklake
 
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
-        delete_ducklake(metadata_path, "test", pl.col("a") == 1)
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 1)
 
-        drop_ducklake_table(metadata_path, "test")
+        drop_ducklake_table(cat.metadata_path, "test")
 
-        con = sqlite3.connect(metadata_path)
         # Delete files should also be ended
-        active_deletes = con.execute(
+        active_deletes = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_delete_file WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
+        )[0]
         assert active_deletes == 0
-        con.close()
 
-    def test_drop_table_time_travel(self, tmp_path):
+    def test_drop_table_time_travel(self, make_write_catalog):
         """Time travel can read the table before it was dropped."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        snap_before = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        drop_ducklake_table(metadata_path, "test")
+        drop_ducklake_table(cat.metadata_path, "test")
 
         # Latest: table is gone
         with pytest.raises(ValueError, match="not found"):
-            read_ducklake(metadata_path, "test")
+            read_ducklake(cat.metadata_path, "test")
 
         # Before drop: table exists
         result = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_before
+            cat.metadata_path, "test", snapshot_version=snap_before
         )
         assert result["a"].to_list() == [1, 2, 3]
 
-    def test_drop_table_nonexistent_raises(self, tmp_path):
+    def test_drop_table_nonexistent_raises(self, make_write_catalog):
         """Dropping a nonexistent table raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         with pytest.raises(ValueError, match="not found"):
-            drop_ducklake_table(metadata_path, "missing")
+            drop_ducklake_table(cat.metadata_path, "missing")
 
-    def test_drop_table_duckdb_interop(self, tmp_path):
+    def test_drop_table_duckdb_interop(self, make_write_catalog):
         """DuckDB confirms table is dropped."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        drop_ducklake_table(metadata_path, "test")
+        drop_ducklake_table(cat.metadata_path, "test")
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         with pytest.raises(duckdb.CatalogException):
             con.execute("SELECT * FROM ducklake.test")
         con.close()
 
-    def test_duckdb_drop_table_polars_reads(self, tmp_path):
+    def test_duckdb_drop_table_polars_reads(self, make_write_catalog):
         """DuckDB drops a table, polars confirms it's gone."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER)")
         con.execute("INSERT INTO ducklake.test VALUES (1)")
@@ -422,20 +371,20 @@ class TestDropTable:
         con.close()
 
         with pytest.raises(ValueError, match="not found"):
-            read_ducklake(metadata_path, "test")
+            read_ducklake(cat.metadata_path, "test")
 
-    def test_drop_and_recreate_table(self, tmp_path):
+    def test_drop_and_recreate_table(self, make_write_catalog):
         """Drop a table and create a new one with the same name."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df1, metadata_path, "test", mode="error")
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
 
-        drop_ducklake_table(metadata_path, "test")
+        drop_ducklake_table(cat.metadata_path, "test")
 
         df2 = pl.DataFrame({"x": ["hello", "world"]})
-        write_ducklake(df2, metadata_path, "test", mode="error")
+        write_ducklake(df2, cat.metadata_path, "test", mode="error")
 
-        result = read_ducklake(metadata_path, "test").sort("x")
+        result = read_ducklake(cat.metadata_path, "test").sort("x")
         assert result.columns == ["x"]
         assert result["x"].to_list() == ["hello", "world"]
 
@@ -448,134 +397,126 @@ class TestDropTable:
 class TestCreateSchema:
     """Test CREATE SCHEMA."""
 
-    def test_create_schema_basic(self, tmp_path):
+    def test_create_schema_basic(self, make_write_catalog):
         """Create a new schema."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
-        create_ducklake_schema(metadata_path, "myschema")
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT schema_name, path FROM ducklake_schema "
             "WHERE schema_name = 'myschema' AND end_snapshot IS NULL"
-        ).fetchone()
+        )
         assert row is not None
         assert row[0] == "myschema"
         assert row[1] == "myschema/"
-        con.close()
 
-    def test_create_schema_metadata_correct(self, tmp_path):
+    def test_create_schema_metadata_correct(self, make_write_catalog):
         """Verify metadata: snapshot, schema_versions, changes."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        create_ducklake_schema(metadata_path, "myschema")
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
-        con = sqlite3.connect(metadata_path)
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
         # Schema version recorded
-        sv_row = con.execute(
+        sv_row = cat.query_one(
             "SELECT schema_version FROM ducklake_schema_versions "
             "ORDER BY begin_snapshot DESC LIMIT 1"
-        ).fetchone()
+        )
         assert sv_row[0] == sv_after
 
         # Changes recorded
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert 'created_schema:"myschema"' in change[0]
 
-        con.close()
-
-    def test_create_schema_duplicate_raises(self, tmp_path):
+    def test_create_schema_duplicate_raises(self, make_write_catalog):
         """Creating a schema that already exists raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
         with pytest.raises(ValueError, match="already exists"):
-            create_ducklake_schema(metadata_path, "myschema")
+            create_ducklake_schema(cat.metadata_path, "myschema")
 
-    def test_create_schema_then_create_table(self, tmp_path):
+    def test_create_schema_then_create_table(self, make_write_catalog):
         """Create a schema, then a table in it."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", schema="myschema", mode="error")
 
-        result = read_ducklake(metadata_path, "test", schema="myschema").sort("a")
+        result = read_ducklake(cat.metadata_path, "test", schema="myschema").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
 
-    def test_create_schema_duckdb_interop(self, tmp_path):
+    def test_create_schema_duckdb_interop(self, make_write_catalog):
         """DuckDB can see a schema created by polars."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
         # Create a table in the schema and write data
         df = pl.DataFrame({"a": [42]})
-        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", schema="myschema", mode="error")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test", "myschema")
+        pdf = cat.read_with_duckdb_schema("test", "myschema")
         assert pdf["a"].to_list() == [42]
 
-    def test_duckdb_create_schema_polars_uses(self, tmp_path):
+    def test_duckdb_create_schema_polars_uses(self, make_write_catalog):
         """DuckDB creates a schema, polars creates a table in it."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE SCHEMA ducklake.myschema")
         con.close()
 
         df = pl.DataFrame({"a": [10, 20]})
-        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", schema="myschema", mode="error")
 
-        result = read_ducklake(metadata_path, "test", schema="myschema").sort("a")
+        result = read_ducklake(cat.metadata_path, "test", schema="myschema").sort("a")
         assert result["a"].to_list() == [10, 20]
 
-    def test_create_multiple_schemas(self, tmp_path):
+    def test_create_multiple_schemas(self, make_write_catalog):
         """Create multiple schemas."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "s1")
-        create_ducklake_schema(metadata_path, "s2")
-        create_ducklake_schema(metadata_path, "s3")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "s1")
+        create_ducklake_schema(cat.metadata_path, "s2")
+        create_ducklake_schema(cat.metadata_path, "s3")
 
-        con = sqlite3.connect(metadata_path)
-        count = con.execute(
+        count = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_schema WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
+        )[0]
         # main + s1 + s2 + s3
         assert count == 4
 
-        names = [
-            r[0]
-            for r in con.execute(
-                "SELECT schema_name FROM ducklake_schema "
-                "WHERE end_snapshot IS NULL ORDER BY schema_id"
-            ).fetchall()
-        ]
+        rows = cat.query_all(
+            "SELECT schema_name FROM ducklake_schema "
+            "WHERE end_snapshot IS NULL ORDER BY schema_id"
+        )
+        names = [r[0] for r in rows]
         assert names == ["main", "s1", "s2", "s3"]
-        con.close()
 
 
 # ===========================================================================
@@ -586,131 +527,131 @@ class TestCreateSchema:
 class TestDropSchema:
     """Test DROP SCHEMA."""
 
-    def test_drop_schema_empty(self, tmp_path):
+    def test_drop_schema_empty(self, make_write_catalog):
         """Drop an empty schema."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
-        drop_ducklake_schema(metadata_path, "myschema")
+        drop_ducklake_schema(cat.metadata_path, "myschema")
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT end_snapshot FROM ducklake_schema "
             "WHERE schema_name = 'myschema'"
-        ).fetchone()
+        )
         assert row is not None
         assert row[0] is not None  # end_snapshot is set
-        con.close()
 
-    def test_drop_schema_metadata_correct(self, tmp_path):
+    def test_drop_schema_metadata_correct(self, make_write_catalog):
         """Verify metadata: snapshot, schema_versions, changes."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        drop_ducklake_schema(metadata_path, "myschema")
+        drop_ducklake_schema(cat.metadata_path, "myschema")
 
-        con = sqlite3.connect(metadata_path)
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert "dropped_schema" in change[0]
-        con.close()
 
-    def test_drop_schema_with_tables_no_cascade_raises(self, tmp_path):
+    def test_drop_schema_with_tables_no_cascade_raises(self, make_write_catalog):
         """Dropping a schema with tables without cascade raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", schema="myschema", mode="error")
 
         with pytest.raises(ValueError, match="entries that depend on it"):
-            drop_ducklake_schema(metadata_path, "myschema")
+            drop_ducklake_schema(cat.metadata_path, "myschema")
 
-    def test_drop_schema_cascade(self, tmp_path):
+    def test_drop_schema_cascade(self, make_write_catalog):
         """Drop a schema with tables using cascade."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", schema="myschema", mode="error")
 
-        drop_ducklake_schema(metadata_path, "myschema", cascade=True)
+        drop_ducklake_schema(cat.metadata_path, "myschema", cascade=True)
 
         # Schema is gone
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT end_snapshot FROM ducklake_schema "
             "WHERE schema_name = 'myschema'"
-        ).fetchone()
+        )
         assert row[0] is not None
 
         # Table is gone
-        active_tables = con.execute(
+        active_tables = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_table WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
+        )[0]
         assert active_tables == 0
 
         # Changes recorded
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert "dropped_schema" in change[0]
         assert "dropped_table" in change[0]
-        con.close()
 
-    def test_drop_schema_nonexistent_raises(self, tmp_path):
+    def test_drop_schema_nonexistent_raises(self, make_write_catalog):
         """Dropping a nonexistent schema raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         with pytest.raises(ValueError, match="not found"):
-            drop_ducklake_schema(metadata_path, "missing")
+            drop_ducklake_schema(cat.metadata_path, "missing")
 
-    def test_drop_schema_duckdb_interop(self, tmp_path):
+    def test_drop_schema_duckdb_interop(self, make_write_catalog):
         """DuckDB confirms dropped schema."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
 
-        drop_ducklake_schema(metadata_path, "myschema")
+        drop_ducklake_schema(cat.metadata_path, "myschema")
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         with pytest.raises((duckdb.CatalogException, duckdb.BinderException)):
             con.execute("CREATE TABLE ducklake.myschema.test (a INTEGER)")
         con.close()
 
-    def test_duckdb_drop_schema_polars_confirms(self, tmp_path):
+    def test_duckdb_drop_schema_polars_confirms(self, make_write_catalog):
         """DuckDB drops a schema, polars can no longer use it."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE SCHEMA ducklake.myschema")
         con.execute("DROP SCHEMA ducklake.myschema")
@@ -719,29 +660,27 @@ class TestDropSchema:
         # Can't create a table in a dropped schema
         with pytest.raises(ValueError, match="not found"):
             create_ducklake_table(
-                metadata_path, "test",
+                cat.metadata_path, "test",
                 {"a": pl.Int64()},
                 schema="myschema",
             )
 
-    def test_drop_schema_cascade_duckdb_interop(self, tmp_path):
+    def test_drop_schema_cascade_duckdb_interop(self, make_write_catalog):
         """DuckDB can read table data from time travel after cascade drop."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        create_ducklake_schema(metadata_path, "myschema")
+        cat = make_write_catalog()
+        create_ducklake_schema(cat.metadata_path, "myschema")
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", schema="myschema", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", schema="myschema", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        snap_before = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        drop_ducklake_schema(metadata_path, "myschema", cascade=True)
+        drop_ducklake_schema(cat.metadata_path, "myschema", cascade=True)
 
         # Time travel works
         result = read_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             schema="myschema", snapshot_version=snap_before,
         ).sort("a")
         assert result["a"].to_list() == [1, 2, 3]
@@ -755,198 +694,199 @@ class TestDropSchema:
 class TestRenameTable:
     """Test RENAME TABLE."""
 
-    def test_rename_table_basic(self, tmp_path):
+    def test_rename_table_basic(self, make_write_catalog):
         """Rename a table and read back by new name."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "t1", mode="error")
+        write_ducklake(df, cat.metadata_path, "t1", mode="error")
 
-        rename_ducklake_table(metadata_path, "t1", "t2")
+        rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
-        result = read_ducklake(metadata_path, "t2").sort("a")
+        result = read_ducklake(cat.metadata_path, "t2").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
 
         # Old name should be gone
         with pytest.raises(ValueError, match="not found"):
-            read_ducklake(metadata_path, "t1")
+            read_ducklake(cat.metadata_path, "t1")
 
-    def test_rename_table_metadata_correct(self, tmp_path):
+    def test_rename_table_metadata_correct(self, make_write_catalog):
         """Verify metadata: old row ended, new row with same table_id."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "t1", mode="error")
+        write_ducklake(df, cat.metadata_path, "t1", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        sv_before = con.execute(
+        sv_before = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
-        old_table = con.execute(
+        )[0]
+        old_table = cat.query_one(
             "SELECT table_id, table_uuid, path FROM ducklake_table "
             "WHERE table_name = 't1' AND end_snapshot IS NULL"
-        ).fetchone()
+        )
         old_table_id = old_table[0]
         old_table_uuid = old_table[1]
         old_path = old_table[2]
-        con.close()
 
-        rename_ducklake_table(metadata_path, "t1", "t2")
+        rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
-        con = sqlite3.connect(metadata_path)
         # Schema version incremented
-        sv_after = con.execute(
+        sv_after = cat.query_one(
             "SELECT schema_version FROM ducklake_snapshot "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()[0]
+        )[0]
         assert sv_after == sv_before + 1
 
         # Old table row ended
-        old_end = con.execute(
+        old_end = cat.query_one(
             "SELECT end_snapshot FROM ducklake_table "
             "WHERE table_name = 't1'"
-        ).fetchone()
+        )
         assert old_end[0] is not None
 
         # New row has same table_id, table_uuid, and path
-        new_table = con.execute(
+        new_table = cat.query_one(
             "SELECT table_id, table_uuid, path FROM ducklake_table "
             "WHERE table_name = 't2' AND end_snapshot IS NULL"
-        ).fetchone()
+        )
         assert new_table[0] == old_table_id
         assert new_table[1] == old_table_uuid
         assert new_table[2] == old_path  # path doesn't change
 
         # Columns unchanged
-        cols = con.execute(
+        cols = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_column "
             "WHERE table_id = ? AND end_snapshot IS NULL",
             [old_table_id],
-        ).fetchone()[0]
+        )[0]
         assert cols > 0
 
         # Data files unchanged
-        files = con.execute(
+        files = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file "
             "WHERE table_id = ? AND end_snapshot IS NULL",
             [old_table_id],
-        ).fetchone()[0]
+        )[0]
         assert files > 0
 
-        con.close()
-
-    def test_rename_table_then_insert(self, tmp_path):
+    def test_rename_table_then_insert(self, make_write_catalog):
         """Insert data after renaming a table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "t1", mode="error")
+        write_ducklake(df, cat.metadata_path, "t1", mode="error")
 
-        rename_ducklake_table(metadata_path, "t1", "t2")
+        rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
         new_row = pl.DataFrame({"a": [3]})
-        write_ducklake(new_row, metadata_path, "t2", mode="append")
+        write_ducklake(new_row, cat.metadata_path, "t2", mode="append")
 
-        result = read_ducklake(metadata_path, "t2").sort("a")
+        result = read_ducklake(cat.metadata_path, "t2").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
 
-    def test_rename_table_time_travel(self, tmp_path):
+    def test_rename_table_time_travel(self, make_write_catalog):
         """Time travel sees the old table name."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "t1", mode="error")
+        write_ducklake(df, cat.metadata_path, "t1", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        snap_before = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        rename_ducklake_table(metadata_path, "t1", "t2")
+        rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
         # Before rename: old name works
         result_old = read_ducklake(
-            metadata_path, "t1", snapshot_version=snap_before
+            cat.metadata_path, "t1", snapshot_version=snap_before
         ).sort("a")
         assert result_old["a"].to_list() == [1, 2]
 
-    def test_rename_table_nonexistent_raises(self, tmp_path):
+    def test_rename_table_nonexistent_raises(self, make_write_catalog):
         """Renaming a nonexistent table raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         with pytest.raises(ValueError, match="not found"):
-            rename_ducklake_table(metadata_path, "missing", "new")
+            rename_ducklake_table(cat.metadata_path, "missing", "new")
 
-    def test_rename_table_duplicate_raises(self, tmp_path):
+    def test_rename_table_duplicate_raises(self, make_write_catalog):
         """Renaming to an existing table name raises."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1]})
-        write_ducklake(df, metadata_path, "t1", mode="error")
-        write_ducklake(df, metadata_path, "t2", mode="error")
+        write_ducklake(df, cat.metadata_path, "t1", mode="error")
+        write_ducklake(df, cat.metadata_path, "t2", mode="error")
 
         with pytest.raises(ValueError, match="already exists"):
-            rename_ducklake_table(metadata_path, "t1", "t2")
+            rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
-    def test_rename_table_duckdb_interop(self, tmp_path):
+    def test_rename_table_duckdb_interop(self, make_write_catalog):
         """DuckDB can read a table renamed by polars."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df, metadata_path, "t1", mode="error")
+        write_ducklake(df, cat.metadata_path, "t1", mode="error")
 
-        rename_ducklake_table(metadata_path, "t1", "t2")
+        rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "t2").sort("a")
+        pdf = cat.read_with_duckdb("t2").sort("a")
         assert pdf["a"].to_list() == [1, 2]
 
         # Old name should fail
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
+
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         with pytest.raises(duckdb.CatalogException):
             con.execute("SELECT * FROM ducklake.t1")
         con.close()
 
-    def test_duckdb_rename_table_polars_reads(self, tmp_path):
+    def test_duckdb_rename_table_polars_reads(self, make_write_catalog):
         """DuckDB renames a table, polars reads by new name."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.t1 (a INTEGER)")
         con.execute("INSERT INTO ducklake.t1 VALUES (1), (2)")
         con.execute("ALTER TABLE ducklake.t1 RENAME TO t2")
         con.close()
 
-        result = read_ducklake(metadata_path, "t2").sort("a")
+        result = read_ducklake(cat.metadata_path, "t2").sort("a")
         assert result["a"].to_list() == [1, 2]
 
         with pytest.raises(ValueError, match="not found"):
-            read_ducklake(metadata_path, "t1")
+            read_ducklake(cat.metadata_path, "t1")
 
-    def test_rename_table_then_create_with_old_name(self, tmp_path):
+    def test_rename_table_then_create_with_old_name(self, make_write_catalog):
         """Rename a table, then create a new table with the old name."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2]})
-        write_ducklake(df1, metadata_path, "t1", mode="error")
+        write_ducklake(df1, cat.metadata_path, "t1", mode="error")
 
-        rename_ducklake_table(metadata_path, "t1", "t2")
+        rename_ducklake_table(cat.metadata_path, "t1", "t2")
 
         df2 = pl.DataFrame({"x": ["hello"]})
-        write_ducklake(df2, metadata_path, "t1", mode="error")
+        write_ducklake(df2, cat.metadata_path, "t1", mode="error")
 
         # Both tables exist
-        r1 = read_ducklake(metadata_path, "t1")
+        r1 = read_ducklake(cat.metadata_path, "t1")
         assert r1.columns == ["x"]
         assert r1["x"].to_list() == ["hello"]
 
-        r2 = read_ducklake(metadata_path, "t2").sort("a")
+        r2 = read_ducklake(cat.metadata_path, "t2").sort("a")
         assert r2["a"].to_list() == [1, 2]

--- a/tests/test_write_delete.py
+++ b/tests/test_write_delete.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import sqlite3
-
 import duckdb
 import polars as pl
 import pytest
@@ -19,47 +16,6 @@ from ducklake_polars import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_catalog(tmp_path):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "delete_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name):
-    """Read a table with DuckDB's DuckLake extension (interop verification)."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
-# ---------------------------------------------------------------------------
 # Basic delete operations
 # ---------------------------------------------------------------------------
 
@@ -67,69 +23,65 @@ def _read_with_duckdb(metadata_path, data_path, table_name):
 class TestDeleteBasic:
     """Test basic delete operations."""
 
-    def test_delete_some_rows(self, tmp_path):
+    def test_delete_some_rows(self, make_write_catalog):
         """Delete a subset of rows, verify remaining."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": [1, 2, 3, 4, 5],
             "b": ["one", "two", "three", "four", "five"],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") > 3)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") > 3)
         assert deleted == 2
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 3
         assert sorted(result["a"].to_list()) == [1, 2, 3]
 
-    def test_delete_single_row(self, tmp_path):
+    def test_delete_single_row(self, make_write_catalog):
         """Delete exactly one row."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [10, 20, 30]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") == 20)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") == 20)
         assert deleted == 1
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [10, 30]
 
-    def test_delete_all_rows(self, tmp_path):
+    def test_delete_all_rows(self, make_write_catalog):
         """Delete all rows from a table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.lit(True))
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.lit(True))
         assert deleted == 3
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 0
         assert result.schema == {"a": pl.Int64}
 
-    def test_delete_no_matching_rows(self, tmp_path):
+    def test_delete_no_matching_rows(self, make_write_catalog):
         """Delete with no matching rows creates no snapshot."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         # Count snapshots before
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute("SELECT COUNT(*) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        snap_before = cat.query_one("SELECT COUNT(*) FROM ducklake_snapshot")[0]
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") > 100)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") > 100)
         assert deleted == 0
 
         # No new snapshot
-        con = sqlite3.connect(metadata_path)
-        snap_after = con.execute("SELECT COUNT(*) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        snap_after = cat.query_one("SELECT COUNT(*) FROM ducklake_snapshot")[0]
         assert snap_after == snap_before
 
         # Data unchanged
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 2, 3]
 
 
@@ -141,29 +93,29 @@ class TestDeleteBasic:
 class TestDeleteMultiple:
     """Test multiple sequential deletes."""
 
-    def test_two_sequential_deletes(self, tmp_path):
+    def test_two_sequential_deletes(self, make_write_catalog):
         """Two deletes narrowing down data."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": list(range(10))})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") < 3)
-        delete_ducklake(metadata_path, "test", pl.col("a") >= 7)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") < 3)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") >= 7)
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [3, 4, 5, 6]
 
-    def test_three_sequential_deletes(self, tmp_path):
+    def test_three_sequential_deletes(self, make_write_catalog):
         """Three deletes."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": list(range(20))})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") < 5)
-        delete_ducklake(metadata_path, "test", pl.col("a") >= 15)
-        delete_ducklake(metadata_path, "test", pl.col("a") == 10)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") < 5)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") >= 15)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 10)
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         expected = [x for x in range(5, 15) if x != 10]
         assert sorted(result["a"].to_list()) == expected
 
@@ -176,47 +128,47 @@ class TestDeleteMultiple:
 class TestDeleteMultiFile:
     """Test deletes spanning multiple data files."""
 
-    def test_delete_from_multiple_files(self, tmp_path):
+    def test_delete_from_multiple_files(self, make_write_catalog):
         """Two inserts (two files), delete from both."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
         df2 = pl.DataFrame({"a": [6, 7, 8, 9, 10]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
         # Delete even numbers from both files
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") % 2 == 0)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") % 2 == 0)
         assert deleted == 5
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 3, 5, 7, 9]
 
-    def test_delete_from_one_of_two_files(self, tmp_path):
+    def test_delete_from_one_of_two_files(self, make_write_catalog):
         """Two files, delete only affects one."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3]})
         df2 = pl.DataFrame({"a": [100, 200, 300]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") < 10)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") < 10)
         assert deleted == 3
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [100, 200, 300]
 
-    def test_delete_all_from_multiple_files(self, tmp_path):
+    def test_delete_all_from_multiple_files(self, make_write_catalog):
         """Delete all rows from multiple files."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2]})
         df2 = pl.DataFrame({"a": [3, 4]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.lit(True))
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.lit(True))
         assert deleted == 4
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 0
 
 
@@ -228,34 +180,34 @@ class TestDeleteMultiFile:
 class TestDeleteThenAppend:
     """Test delete followed by append."""
 
-    def test_delete_then_append(self, tmp_path):
+    def test_delete_then_append(self, make_write_catalog):
         """Delete some rows then append new ones."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") <= 2)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") <= 2)
 
         new_data = pl.DataFrame({"a": [10, 20]})
-        write_ducklake(new_data, metadata_path, "test", mode="append")
+        write_ducklake(new_data, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [3, 4, 5, 10, 20]
 
-    def test_append_then_delete(self, tmp_path):
+    def test_append_then_delete(self, make_write_catalog):
         """Append new data then delete from both old and new."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df1, metadata_path, "test", mode="error")
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
 
         df2 = pl.DataFrame({"a": [4, 5, 6]})
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
         # Delete from both files
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") % 2 == 0)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") % 2 == 0)
         assert deleted == 3  # 2, 4, 6
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 3, 5]
 
 
@@ -267,59 +219,53 @@ class TestDeleteThenAppend:
 class TestDeleteTimeTravel:
     """Test time travel with deletes."""
 
-    def test_time_travel_before_delete(self, tmp_path):
+    def test_time_travel_before_delete(self, make_write_catalog):
         """Read at snapshot before delete sees all rows."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         # Get snapshot after insert
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        snap_before = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
-        delete_ducklake(metadata_path, "test", pl.col("a") > 3)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") > 3)
 
         # Latest: 3 rows
-        result_latest = read_ducklake(metadata_path, "test")
+        result_latest = read_ducklake(cat.metadata_path, "test")
         assert sorted(result_latest["a"].to_list()) == [1, 2, 3]
 
         # Before delete: 5 rows
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_before
+            cat.metadata_path, "test", snapshot_version=snap_before
         )
         assert sorted(result_old["a"].to_list()) == [1, 2, 3, 4, 5]
 
-    def test_time_travel_between_deletes(self, tmp_path):
+    def test_time_travel_between_deletes(self, make_write_catalog):
         """Multiple deletes, read at each intermediate version."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": list(range(10))})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        v0 = con.execute("SELECT MAX(snapshot_id) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        v0 = cat.query_one("SELECT MAX(snapshot_id) FROM ducklake_snapshot")[0]
 
-        delete_ducklake(metadata_path, "test", pl.col("a") < 3)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") < 3)
 
-        con = sqlite3.connect(metadata_path)
-        v1 = con.execute("SELECT MAX(snapshot_id) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        v1 = cat.query_one("SELECT MAX(snapshot_id) FROM ducklake_snapshot")[0]
 
-        delete_ducklake(metadata_path, "test", pl.col("a") >= 7)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") >= 7)
 
         # Latest: [3, 4, 5, 6]
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [3, 4, 5, 6]
 
         # v1: [3, 4, 5, 6, 7, 8, 9]
-        result_v1 = read_ducklake(metadata_path, "test", snapshot_version=v1)
+        result_v1 = read_ducklake(cat.metadata_path, "test", snapshot_version=v1)
         assert sorted(result_v1["a"].to_list()) == [3, 4, 5, 6, 7, 8, 9]
 
         # v0: all 10
-        result_v0 = read_ducklake(metadata_path, "test", snapshot_version=v0)
+        result_v0 = read_ducklake(cat.metadata_path, "test", snapshot_version=v0)
         assert sorted(result_v0["a"].to_list()) == list(range(10))
 
 
@@ -331,53 +277,53 @@ class TestDeleteTimeTravel:
 class TestDeleteDuckDBInterop:
     """Verify delete files are readable by DuckDB."""
 
-    def test_basic_delete_duckdb_reads(self, tmp_path):
+    def test_basic_delete_duckdb_reads(self, make_write_catalog):
         """Write + delete with ducklake-polars, read with DuckDB."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": ["a", "b", "c", "d", "e"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") > 3)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") > 3)
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert sorted(pdf["a"].to_list()) == [1, 2, 3]
 
-    def test_delete_all_duckdb_reads(self, tmp_path):
+    def test_delete_all_duckdb_reads(self, make_write_catalog):
         """Delete all rows, DuckDB should see empty table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.lit(True))
+        delete_ducklake(cat.metadata_path, "test", pl.lit(True))
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 0
 
-    def test_multi_file_delete_duckdb_reads(self, tmp_path):
+    def test_multi_file_delete_duckdb_reads(self, make_write_catalog):
         """Multi-file delete interop."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3]})
         df2 = pl.DataFrame({"a": [4, 5, 6]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") % 2 == 0)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") % 2 == 0)
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert sorted(pdf["a"].to_list()) == [1, 3, 5]
 
-    def test_delete_then_append_duckdb_reads(self, tmp_path):
+    def test_delete_then_append_duckdb_reads(self, make_write_catalog):
         """Delete + append, verify DuckDB reads correctly."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") == 2)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 2)
 
         new_data = pl.DataFrame({"a": [10]})
-        write_ducklake(new_data, metadata_path, "test", mode="append")
+        write_ducklake(new_data, cat.metadata_path, "test", mode="append")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert sorted(pdf["a"].to_list()) == [1, 3, 10]
 
 
@@ -389,19 +335,22 @@ class TestDeleteDuckDBInterop:
 class TestDuckDBWritePolarsDelete:
     """DuckDB creates the data, ducklake-polars deletes, both read."""
 
-    def test_duckdb_write_polars_delete(self, tmp_path):
+    def test_duckdb_write_polars_delete(self, make_write_catalog):
         """Write with DuckDB, delete with ducklake-polars, read with both."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
 
         # Write data with DuckDB
+        if cat.backend == "sqlite":
+            attach_source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            attach_source = f"ducklake:postgres:{cat.metadata_path}"
+
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{attach_source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
         con.execute(
@@ -411,15 +360,15 @@ class TestDuckDBWritePolarsDelete:
         con.close()
 
         # Delete with ducklake-polars
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") > 3)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") > 3)
         assert deleted == 2
 
         # Read with ducklake-polars
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 2, 3]
 
         # Read with DuckDB
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert sorted(pdf["a"].to_list()) == [1, 2, 3]
 
 
@@ -431,20 +380,18 @@ class TestDuckDBWritePolarsDelete:
 class TestDeleteMetadata:
     """Verify delete file metadata is correctly stored."""
 
-    def test_delete_file_registered(self, tmp_path):
+    def test_delete_file_registered(self, make_write_catalog):
         """Check ducklake_delete_file entries."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") > 3)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") > 3)
 
-        con = sqlite3.connect(metadata_path)
-        rows = con.execute(
+        rows = cat.query_all(
             "SELECT delete_file_id, data_file_id, path, format, delete_count "
             "FROM ducklake_delete_file"
-        ).fetchall()
-        con.close()
+        )
 
         assert len(rows) == 1
         row = rows[0]
@@ -453,86 +400,76 @@ class TestDeleteMetadata:
         assert row[3] == "parquet"
         assert row[4] == 2  # deleted 2 rows (a=4, a=5)
 
-    def test_snapshot_changes_recorded(self, tmp_path):
+    def test_snapshot_changes_recorded(self, make_write_catalog):
         """Check snapshot_changes has deleted_from_table entry."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") == 2)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 2)
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert row is not None
         assert "deleted_from_table" in row[0]
 
-    def test_delete_file_naming(self, tmp_path):
+    def test_delete_file_naming(self, make_write_catalog):
         """Delete file follows ducklake-{uuid}-delete.parquet naming."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") == 1)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 1)
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute("SELECT path FROM ducklake_delete_file LIMIT 1").fetchone()
-        con.close()
+        row = cat.query_one("SELECT path FROM ducklake_delete_file LIMIT 1")
 
         assert row is not None
         path = row[0]
         assert path.startswith("ducklake-")
         assert "-delete.parquet" in path
 
-    def test_delete_file_id_from_shared_counter(self, tmp_path):
+    def test_delete_file_id_from_shared_counter(self, make_write_catalog):
         """delete_file_id is allocated from the same next_file_id counter."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         # After write, next_file_id should be 1 (data_file_id=0 was used)
-        con = sqlite3.connect(metadata_path)
-        snap = con.execute(
+        snap = cat.query_one(
             "SELECT next_file_id FROM ducklake_snapshot ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         file_id_before = snap[0]
-        con.close()
 
-        delete_ducklake(metadata_path, "test", pl.col("a") == 2)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 2)
 
-        con = sqlite3.connect(metadata_path)
-        del_row = con.execute(
+        del_row = cat.query_one(
             "SELECT delete_file_id FROM ducklake_delete_file"
-        ).fetchone()
-        snap_after = con.execute(
+        )
+        snap_after = cat.query_one(
             "SELECT next_file_id FROM ducklake_snapshot ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert del_row[0] == file_id_before  # delete_file_id = previous next_file_id
         assert snap_after[0] == file_id_before + 1  # counter incremented
 
-    def test_multi_file_delete_creates_multiple_delete_files(self, tmp_path):
+    def test_multi_file_delete_creates_multiple_delete_files(self, make_write_catalog):
         """Each affected data file gets its own delete file."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3]})
         df2 = pl.DataFrame({"a": [4, 5, 6]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
         # Delete even numbers from both files
-        delete_ducklake(metadata_path, "test", pl.col("a") % 2 == 0)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") % 2 == 0)
 
-        con = sqlite3.connect(metadata_path)
-        del_rows = con.execute(
+        del_rows = cat.query_all(
             "SELECT delete_file_id, data_file_id, delete_count "
             "FROM ducklake_delete_file ORDER BY delete_file_id"
-        ).fetchall()
-        con.close()
+        )
 
         assert len(del_rows) == 2  # one per affected data file
         # Each file has one even number deleted
@@ -548,76 +485,76 @@ class TestDeleteMetadata:
 class TestDeleteEdgeCases:
     """Edge cases for the delete path."""
 
-    def test_delete_from_empty_table(self, tmp_path):
+    def test_delete_from_empty_table(self, make_write_catalog):
         """Delete from empty table returns 0."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         schema = {"a": pl.Int32()}
         from ducklake_polars import create_ducklake_table
-        create_ducklake_table(metadata_path, "test", schema)
+        create_ducklake_table(cat.metadata_path, "test", schema)
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") > 0)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") > 0)
         assert deleted == 0
 
-    def test_delete_with_string_predicate(self, tmp_path):
+    def test_delete_with_string_predicate(self, make_write_catalog):
         """Delete using string column predicate."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "name": ["alice", "bob", "charlie"],
             "age": [30, 25, 35],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("name") == "bob")
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("name") == "bob")
         assert deleted == 1
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["name"].to_list()) == ["alice", "charlie"]
 
-    def test_delete_with_compound_predicate(self, tmp_path):
+    def test_delete_with_compound_predicate(self, make_write_catalog):
         """Delete using AND/OR predicates."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": [1, 2, 3, 4, 5],
             "b": ["x", "y", "x", "y", "x"],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         # Delete where a > 2 AND b == "x"
         deleted = delete_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             (pl.col("a") > 2) & (pl.col("b") == "x"),
         )
         assert deleted == 2  # a=3,b=x and a=5,b=x
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 2, 4]
 
-    def test_delete_preserves_schema(self, tmp_path):
+    def test_delete_preserves_schema(self, make_write_catalog):
         """After deleting all rows, schema is preserved."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "x": pl.Series([1, 2], dtype=pl.Int32),
             "y": ["a", "b"],
             "z": [1.0, 2.0],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.lit(True))
+        delete_ducklake(cat.metadata_path, "test", pl.lit(True))
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape == (0, 3)
         assert result.schema == {"x": pl.Int32, "y": pl.String, "z": pl.Float64}
 
-    def test_scan_after_delete(self, tmp_path):
+    def test_scan_after_delete(self, make_write_catalog):
         """scan_ducklake with filter after delete."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": list(range(100))})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        delete_ducklake(metadata_path, "test", pl.col("a") < 50)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") < 50)
 
         result = (
-            scan_ducklake(metadata_path, "test")
+            scan_ducklake(cat.metadata_path, "test")
             .filter(pl.col("a") >= 75)
             .collect()
         )

--- a/tests/test_write_inline.py
+++ b/tests/test_write_inline.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import sqlite3
-
 import duckdb
 import polars as pl
 import pytest
@@ -26,42 +23,6 @@ from ducklake_polars import (
 INLINE_LIMIT = 1000
 
 
-def _make_catalog(tmp_path, inline_limit=INLINE_LIMIT):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "inline_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name, inline_limit=INLINE_LIMIT):
-    """Read a table with DuckDB's DuckLake extension (interop verification)."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT {inline_limit})"
-    )
-    cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
 # ---------------------------------------------------------------------------
 # Basic inlined insert
 # ---------------------------------------------------------------------------
@@ -70,80 +31,78 @@ def _read_with_duckdb(metadata_path, data_path, table_name, inline_limit=INLINE_
 class TestInlinedInsert:
     """Test that small inserts go into inlined data tables."""
 
-    def test_basic_inlined_insert(self, tmp_path):
+    def test_basic_inlined_insert(self, make_write_catalog):
         """Small insert below threshold is inlined — no Parquet files written."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         # Read back with ducklake-polars
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert_frame_equal(result.sort("a"), df.sort("a"))
 
         # Verify data is inlined — no Parquet data files
-        con = sqlite3.connect(metadata_path)
-        data_files = con.execute(
+        row = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file"
-        ).fetchone()[0]
-        assert data_files == 0
+        )
+        assert row[0] == 0
 
         # Verify inlined data table exists
-        inlined = con.execute(
+        inlined = cat.query_all(
             "SELECT table_name FROM ducklake_inlined_data_tables"
-        ).fetchall()
+        )
         assert len(inlined) >= 1
 
         # Verify inlined data has correct row count
         tbl_name = inlined[0][0]
         safe = tbl_name.replace('"', '""')
-        row_count = con.execute(
+        row = cat.query_one(
             f'SELECT COUNT(*) FROM "{safe}" WHERE end_snapshot IS NULL'
-        ).fetchone()[0]
-        assert row_count == 3
-        con.close()
+        )
+        assert row[0] == 3
 
-    def test_inlined_insert_roundtrip(self, tmp_path):
+    def test_inlined_insert_roundtrip(self, make_write_catalog):
         """Write inlined, read back with scan_ducklake."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"x": [10, 20, 30], "y": [1.1, 2.2, 3.3]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        result = scan_ducklake(metadata_path, "test").filter(
+        result = scan_ducklake(cat.metadata_path, "test").filter(
             pl.col("x") > 15
         ).collect()
         result = result.sort("x")
         assert result["x"].to_list() == [20, 30]
         assert result["y"].to_list() == [2.2, 3.3]
 
-    def test_inlined_multiple_inserts(self, tmp_path):
+    def test_inlined_multiple_inserts(self, make_write_catalog):
         """Multiple inlined inserts accumulate correctly."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2]})
         df2 = pl.DataFrame({"a": [3, 4]})
 
         write_ducklake(
-            df1, metadata_path, "test",
+            df1, cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
         write_ducklake(
-            df2, metadata_path, "test",
+            df2, cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 2, 3, 4]
 
-    def test_inlined_various_types(self, tmp_path):
+    def test_inlined_various_types(self, make_write_catalog):
         """Verify inlining with various column types."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "int_col": pl.Series([1, 2], dtype=pl.Int32),
             "bigint_col": pl.Series([100, 200], dtype=pl.Int64),
@@ -153,11 +112,11 @@ class TestInlinedInsert:
         })
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape == (2, 5)
         assert sorted(result["int_col"].to_list()) == [1, 2]
         assert sorted(result["str_col"].to_list()) == ["hello", "world"]
@@ -172,33 +131,33 @@ class TestInlinedInsert:
 class TestInlinedDuckDBInterop:
     """DuckDB can read inlined data written by ducklake-polars."""
 
-    def test_duckdb_reads_inlined(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_duckdb_reads_inlined(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test", inline_limit=INLINE_LIMIT)
         assert len(pdf) == 3
         assert sorted(pdf["a"].to_list()) == [1, 2, 3]
         assert sorted(pdf["b"].to_list()) == ["x", "y", "z"]
 
-    def test_duckdb_reads_after_multiple_inlined_inserts(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_duckdb_reads_after_multiple_inlined_inserts(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"v": [10, 20]}), metadata_path, "test",
+            pl.DataFrame({"v": [10, 20]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
         write_ducklake(
-            pl.DataFrame({"v": [30]}), metadata_path, "test",
+            pl.DataFrame({"v": [30]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test", inline_limit=INLINE_LIMIT)
         assert sorted(pdf["v"].to_list()) == [10, 20, 30]
 
 
@@ -210,17 +169,19 @@ class TestInlinedDuckDBInterop:
 class TestDuckDBInlinedPolarsRead:
     """ducklake-polars reads inlined data written by DuckDB."""
 
-    def test_duckdb_inline_polars_read(self, tmp_path):
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+    def test_duckdb_inline_polars_read(self, make_write_catalog):
+        cat = make_write_catalog(inline=True, inline_limit=1000)
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
+        if cat.backend == "sqlite":
+            attach_source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            attach_source = f"ducklake:postgres:{cat.metadata_path}"
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 1000)"
+            f"ATTACH '{attach_source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 1000)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
         con.execute(
@@ -228,7 +189,7 @@ class TestDuckDBInlinedPolarsRead:
         )
         con.close()
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         result = result.sort("a")
         assert result.shape == (3, 2)
         assert result["a"].to_list() == [1, 2, 3]
@@ -243,92 +204,92 @@ class TestDuckDBInlinedPolarsRead:
 class TestInlinedDelete:
     """Test deleting from inlined data sets end_snapshot."""
 
-    def test_delete_inlined_rows(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_delete_inlined_rows(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": ["a", "b", "c", "d", "e"]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         deleted = delete_ducklake(
-            metadata_path, "test", pl.col("a") == 3,
+            cat.metadata_path, "test", pl.col("a") == 3,
             data_inlining_row_limit=INLINE_LIMIT,
         )
         assert deleted == 1
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         result = result.sort("a")
         assert result["a"].to_list() == [1, 2, 4, 5]
         assert result["b"].to_list() == ["a", "b", "d", "e"]
 
-    def test_delete_multiple_inlined_rows(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_delete_multiple_inlined_rows(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         deleted = delete_ducklake(
-            metadata_path, "test", pl.col("a") > 3,
+            cat.metadata_path, "test", pl.col("a") > 3,
             data_inlining_row_limit=INLINE_LIMIT,
         )
         assert deleted == 2
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 2, 3]
 
-    def test_delete_all_inlined_rows(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_delete_all_inlined_rows(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         deleted = delete_ducklake(
-            metadata_path, "test", pl.lit(True),
+            cat.metadata_path, "test", pl.lit(True),
             data_inlining_row_limit=INLINE_LIMIT,
         )
         assert deleted == 3
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 0
 
-    def test_delete_no_match_returns_zero(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_delete_no_match_returns_zero(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         deleted = delete_ducklake(
-            metadata_path, "test", pl.col("a") > 100,
+            cat.metadata_path, "test", pl.col("a") > 100,
             data_inlining_row_limit=INLINE_LIMIT,
         )
         assert deleted == 0
 
-    def test_delete_inlined_duckdb_interop(self, tmp_path):
+    def test_delete_inlined_duckdb_interop(self, make_write_catalog):
         """DuckDB can read after inlined delete by ducklake-polars."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
         delete_ducklake(
-            metadata_path, "test", pl.col("a") == 2,
+            cat.metadata_path, "test", pl.col("a") == 2,
             data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test", inline_limit=INLINE_LIMIT)
         assert len(pdf) == 2
         assert sorted(pdf["a"].to_list()) == [1, 3]
 
@@ -341,63 +302,57 @@ class TestInlinedDelete:
 class TestInlineThreshold:
     """Test that inserts exceeding the threshold go to Parquet."""
 
-    def test_exceed_threshold_goes_to_parquet(self, tmp_path):
+    def test_exceed_threshold_goes_to_parquet(self, make_write_catalog):
         """Insert exceeding limit writes to Parquet, not inline."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         small_df = pl.DataFrame({"a": list(range(5))})
 
         # First insert: inlined (5 rows < 10 limit)
         write_ducklake(
-            small_df, metadata_path, "test",
+            small_df, cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=10,
         )
 
         # Verify inlined
-        con = sqlite3.connect(metadata_path)
-        data_files = con.execute(
+        row = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
-        assert data_files == 0
-        con.close()
+        )
+        assert row[0] == 0
 
         # Second insert: 6 more rows, total would be 11 > 10 limit
         big_df = pl.DataFrame({"a": list(range(100, 106))})
         write_ducklake(
-            big_df, metadata_path, "test",
+            big_df, cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=10,
         )
 
         # Now there should be a Parquet file
-        con = sqlite3.connect(metadata_path)
-        data_files = con.execute(
+        row = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
-        ).fetchone()[0]
-        assert data_files == 1
-        con.close()
+        )
+        assert row[0] == 1
 
         # Both inlined and Parquet rows should be readable
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 11
         expected = list(range(5)) + list(range(100, 106))
         assert sorted(result["a"].to_list()) == sorted(expected)
 
-    def test_disabled_inlining(self, tmp_path):
+    def test_disabled_inlining(self, make_write_catalog):
         """data_inlining_row_limit=0 means no inlining."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=0,
         )
 
         # Should have a Parquet file
-        con = sqlite3.connect(metadata_path)
-        data_files = con.execute(
+        row = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file"
-        ).fetchone()[0]
-        assert data_files == 1
-        con.close()
+        )
+        assert row[0] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -408,63 +363,61 @@ class TestInlineThreshold:
 class TestInlinedTimeTravel:
     """Test time travel with inlined data."""
 
-    def test_time_travel_inlined(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_time_travel_inlined(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [1, 2]}), metadata_path, "test",
+            pl.DataFrame({"a": [1, 2]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         # Get snapshot after first insert
-        con = sqlite3.connect(metadata_path)
-        snap_v1 = con.execute(
+        row = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )
+        snap_v1 = row[0]
 
         write_ducklake(
-            pl.DataFrame({"a": [3, 4]}), metadata_path, "test",
+            pl.DataFrame({"a": [3, 4]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         # Latest: 4 rows
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 4
 
         # At v1: 2 rows
         result_v1 = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_v1
+            cat.metadata_path, "test", snapshot_version=snap_v1
         )
         assert result_v1.shape[0] == 2
         assert sorted(result_v1["a"].to_list()) == [1, 2]
 
-    def test_time_travel_after_inlined_delete(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_time_travel_after_inlined_delete(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [1, 2, 3]}), metadata_path, "test",
+            pl.DataFrame({"a": [1, 2, 3]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        con = sqlite3.connect(metadata_path)
-        snap_before_delete = con.execute(
+        row = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )
+        snap_before_delete = row[0]
 
         delete_ducklake(
-            metadata_path, "test", pl.col("a") == 2,
+            cat.metadata_path, "test", pl.col("a") == 2,
             data_inlining_row_limit=INLINE_LIMIT,
         )
 
         # Current: 2 rows
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert sorted(result["a"].to_list()) == [1, 3]
 
         # Before delete: 3 rows
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_before_delete,
+            cat.metadata_path, "test", snapshot_version=snap_before_delete,
         )
         assert sorted(result_old["a"].to_list()) == [1, 2, 3]
 
@@ -477,34 +430,34 @@ class TestInlinedTimeTravel:
 class TestInlinedOverwrite:
     """Test overwrite mode with inlined data."""
 
-    def test_overwrite_inlined(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_overwrite_inlined(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [1, 2, 3]}), metadata_path, "test",
+            pl.DataFrame({"a": [1, 2, 3]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
         write_ducklake(
-            pl.DataFrame({"a": [99]}), metadata_path, "test",
+            pl.DataFrame({"a": [99]}), cat.metadata_path, "test",
             mode="overwrite", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result["a"].to_list() == [99]
 
-    def test_overwrite_inlined_duckdb_interop(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_overwrite_inlined_duckdb_interop(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [1, 2, 3]}), metadata_path, "test",
+            pl.DataFrame({"a": [1, 2, 3]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
         write_ducklake(
-            pl.DataFrame({"a": [42]}), metadata_path, "test",
+            pl.DataFrame({"a": [42]}), cat.metadata_path, "test",
             mode="overwrite", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test", inline_limit=INLINE_LIMIT)
         assert pdf["a"].to_list() == [42]
 
 
@@ -516,45 +469,45 @@ class TestInlinedOverwrite:
 class TestInlinedUpdate:
     """Test UPDATE on tables with inlined data."""
 
-    def test_update_inlined_rows(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_update_inlined_rows(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         updated = update_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"b": "updated"},
             pl.col("a") == 2,
             data_inlining_row_limit=INLINE_LIMIT,
         )
         assert updated == 1
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         result = result.sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["x", "updated", "z"]
 
-    def test_update_inlined_duckdb_interop(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_update_inlined_duckdb_interop(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["old", "old", "old"]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
         update_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"b": "new"},
             pl.col("a") <= 2,
             data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test", inline_limit=INLINE_LIMIT)
         pdf_sorted = pdf.sort("a")
         assert pdf_sorted["a"].to_list() == [1, 2, 3]
         assert pdf_sorted["b"].to_list() == ["new", "new", "old"]
@@ -568,19 +521,19 @@ class TestInlinedUpdate:
 class TestInlinedNulls:
     """Test NULL handling in inlined data."""
 
-    def test_inlined_nulls(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_inlined_nulls(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": pl.Series([1, None, 3], dtype=pl.Int64),
             "b": ["hello", None, "world"],
         })
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         result = result.sort("a", nulls_last=True)
         assert result["a"].to_list() == [1, 3, None]
         assert result["b"].to_list() == ["hello", "world", None]
@@ -594,22 +547,20 @@ class TestInlinedNulls:
 class TestInlinedMetadata:
     """Test that metadata tables are correctly populated."""
 
-    def test_inlined_data_table_registration(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_inlined_data_table_registration(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({"x": [1, 2]})
 
         write_ducklake(
-            df, metadata_path, "test",
+            df, cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        con = sqlite3.connect(metadata_path)
-
         # Check ducklake_inlined_data_tables
-        row = con.execute(
+        row = cat.query_one(
             "SELECT table_id, table_name, schema_version "
             "FROM ducklake_inlined_data_tables"
-        ).fetchone()
+        )
         assert row is not None
         table_id = row[0]
         tbl_name = row[1]
@@ -619,81 +570,71 @@ class TestInlinedMetadata:
         assert tbl_name == f"ducklake_inlined_data_{table_id}_{schema_ver}"
 
         # Check inlined data table has correct structure
-        safe = tbl_name.replace('"', '""')
-        cols = con.execute(
-            f'PRAGMA table_info("{safe}")'
-        ).fetchall()
-        col_names = [c[1] for c in cols]
+        cols = cat.get_table_columns(tbl_name)
+        col_names = [c[0] for c in cols]
         assert "row_id" in col_names
         assert "begin_snapshot" in col_names
         assert "end_snapshot" in col_names
         assert "x" in col_names
 
-        con.close()
-
-    def test_table_stats_updated(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_table_stats_updated(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [1, 2]}), metadata_path, "test",
+            pl.DataFrame({"a": [1, 2]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
         write_ducklake(
-            pl.DataFrame({"a": [3]}), metadata_path, "test",
+            pl.DataFrame({"a": [3]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT record_count, next_row_id FROM ducklake_table_stats"
-        ).fetchone()
-        con.close()
+        )
 
         assert row is not None
         assert row[0] == 3  # total records
         assert row[1] == 3  # next_row_id
 
-    def test_snapshot_changes_recorded(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_snapshot_changes_recorded(self, make_write_catalog):
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [1]}), metadata_path, "test",
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test",
             mode="error", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        con = sqlite3.connect(metadata_path)
-        changes = con.execute(
+        changes = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert changes is not None
         assert "inserted_into_table" in changes[0]
 
-    def test_row_ids_sequential(self, tmp_path):
+    def test_row_ids_sequential(self, make_write_catalog):
         """Row IDs in inlined data are sequential across inserts."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         write_ducklake(
-            pl.DataFrame({"a": [10, 20]}), metadata_path, "test",
+            pl.DataFrame({"a": [10, 20]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
         write_ducklake(
-            pl.DataFrame({"a": [30]}), metadata_path, "test",
+            pl.DataFrame({"a": [30]}), cat.metadata_path, "test",
             mode="append", data_inlining_row_limit=INLINE_LIMIT,
         )
 
-        con = sqlite3.connect(metadata_path)
         # Find the inlined data table
-        tbl_name = con.execute(
+        row = cat.query_one(
             "SELECT table_name FROM ducklake_inlined_data_tables LIMIT 1"
-        ).fetchone()[0]
+        )
+        tbl_name = row[0]
         safe = tbl_name.replace('"', '""')
-        rows = con.execute(
+        rows = cat.query_all(
             f'SELECT row_id FROM "{safe}" ORDER BY row_id'
-        ).fetchall()
-        con.close()
+        )
 
         row_ids = [r[0] for r in rows]
         assert row_ids == [0, 1, 2]

--- a/tests/test_write_merge.py
+++ b/tests/test_write_merge.py
@@ -1,0 +1,608 @@
+"""Tests for ducklake-polars MERGE and CREATE TABLE AS support."""
+
+from __future__ import annotations
+
+import duckdb
+import polars as pl
+
+from ducklake_polars import (
+    create_table_as_ducklake,
+    merge_ducklake,
+    read_ducklake,
+    scan_ducklake,
+    write_ducklake,
+)
+
+
+# ---------------------------------------------------------------------------
+# CREATE TABLE AS
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTableAs:
+    """Test create_table_as_ducklake (single-snapshot create + insert)."""
+
+    def test_create_table_as_basic(self, make_write_catalog):
+        """Create a table from a DataFrame in one operation."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        create_table_as_ducklake(df, cat.metadata_path, "test")
+
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
+        assert result["a"].to_list() == [1, 2, 3]
+        assert result["b"].to_list() == ["x", "y", "z"]
+
+    def test_create_table_as_single_snapshot(self, make_write_catalog):
+        """Only one snapshot should be created (not create + insert)."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1, 2, 3]})
+
+        snap_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+
+        create_table_as_ducklake(df, cat.metadata_path, "test")
+
+        snap_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+        assert snap_after == snap_before + 1
+
+    def test_create_table_as_empty_df(self, make_write_catalog):
+        """Create a table with an empty DataFrame (schema only, no data)."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": pl.Series([], dtype=pl.Int64), "b": pl.Series([], dtype=pl.String)})
+        create_table_as_ducklake(df, cat.metadata_path, "test")
+
+        result = read_ducklake(cat.metadata_path, "test")
+        assert result.shape == (0, 2)
+        assert result.columns == ["a", "b"]
+
+    def test_create_table_as_already_exists(self, make_write_catalog):
+        """Should raise if the table already exists."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1]})
+        create_table_as_ducklake(df, cat.metadata_path, "test")
+
+        import pytest
+
+        with pytest.raises(ValueError, match="already exists"):
+            create_table_as_ducklake(df, cat.metadata_path, "test")
+
+    def test_create_table_as_multiple_types(self, make_write_catalog):
+        """Create a table with various column types."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({
+            "i": [1, 2, 3],
+            "f": [1.5, 2.5, 3.5],
+            "s": ["a", "b", "c"],
+            "b": [True, False, True],
+        })
+        create_table_as_ducklake(df, cat.metadata_path, "multi")
+
+        result = read_ducklake(cat.metadata_path, "multi").sort("i")
+        assert result["i"].to_list() == [1, 2, 3]
+        assert result["f"].to_list() == [1.5, 2.5, 3.5]
+        assert result["s"].to_list() == ["a", "b", "c"]
+        assert result["b"].to_list() == [True, False, True]
+
+    def test_create_table_as_duckdb_reads(self, make_write_catalog):
+        """DuckDB can read a table created with create_table_as_ducklake."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [10, 20, 30], "b": ["x", "y", "z"]})
+        create_table_as_ducklake(df, cat.metadata_path, "test")
+
+        pdf = cat.read_with_duckdb("test").sort("a")
+        assert pdf["a"].to_list() == [10, 20, 30]
+        assert pdf["b"].to_list() == ["x", "y", "z"]
+
+    def test_create_table_as_then_append(self, make_write_catalog):
+        """Create a table, then append more data."""
+        cat = make_write_catalog()
+        df1 = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        create_table_as_ducklake(df1, cat.metadata_path, "test")
+
+        df2 = pl.DataFrame({"a": [3, 4], "b": ["p", "q"]})
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
+
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
+        assert result["a"].to_list() == [1, 2, 3, 4]
+        assert result["b"].to_list() == ["x", "y", "p", "q"]
+
+
+# ---------------------------------------------------------------------------
+# MERGE: basic operations
+# ---------------------------------------------------------------------------
+
+
+class TestMergeBasic:
+    """Test basic merge operations."""
+
+    def test_merge_insert_only(self, make_write_catalog):
+        """Merge with no matches should insert all source rows."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [3, 4], "val": ["c", "d"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_not_matched_insert=True,
+        )
+        assert updated == 0
+        assert inserted == 2
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["id"].to_list() == [1, 2, 3, 4]
+        assert result["val"].to_list() == ["a", "b", "c", "d"]
+
+    def test_merge_update_only(self, make_write_catalog):
+        """Merge with all matches should update, no inserts."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [2, 3], "val": ["B", "C"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+            when_not_matched_insert=False,
+        )
+        assert updated == 2
+        assert inserted == 0
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["id"].to_list() == [1, 2, 3]
+        assert result["val"].to_list() == ["a", "B", "C"]
+
+    def test_merge_upsert(self, make_write_catalog):
+        """Classic upsert: update matched, insert unmatched."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [2, 4], "val": ["B", "D"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+            when_not_matched_insert=True,
+        )
+        assert updated == 1
+        assert inserted == 1
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["id"].to_list() == [1, 2, 3, 4]
+        assert result["val"].to_list() == ["a", "B", "c", "D"]
+
+    def test_merge_no_op(self, make_write_catalog):
+        """Merge with no changes creates no snapshot."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        snap_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+
+        source = pl.DataFrame({"id": [1, 2], "val": ["X", "Y"]})
+        # No update (when_matched_update=None), and keys already exist so
+        # when_not_matched_insert finds nothing
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=None,
+            when_not_matched_insert=True,
+        )
+        assert updated == 0
+        assert inserted == 0
+
+        snap_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+        assert snap_after == snap_before
+
+    def test_merge_with_dict_update(self, make_write_catalog):
+        """Merge with dict-based update: set specific column values."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"], "score": [10, 20, 30]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [2, 3], "val": ["B", "C"], "score": [200, 300]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update={"val": "MERGED"},
+            when_not_matched_insert=False,
+        )
+        assert updated == 2
+        assert inserted == 0
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["val"].to_list() == ["a", "MERGED", "MERGED"]
+        # score should be unchanged (dict update only modified val)
+        assert result["score"].to_list() == [10, 20, 30]
+
+
+# ---------------------------------------------------------------------------
+# MERGE: multi-key columns
+# ---------------------------------------------------------------------------
+
+
+class TestMergeMultiKey:
+    """Test merge with composite key columns."""
+
+    def test_merge_composite_key(self, make_write_catalog):
+        """Merge matching on two key columns."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({
+            "k1": [1, 1, 2, 2],
+            "k2": ["a", "b", "a", "b"],
+            "val": ["v1", "v2", "v3", "v4"],
+        })
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({
+            "k1": [1, 2, 3],
+            "k2": ["b", "c", "a"],
+            "val": ["V2", "V_new", "V_new2"],
+        })
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, ["k1", "k2"],
+            when_matched_update=True,
+            when_not_matched_insert=True,
+        )
+        assert updated == 1  # (1, "b") matched
+        assert inserted == 2  # (2, "c") and (3, "a") unmatched
+
+        result = read_ducklake(cat.metadata_path, "test").sort(["k1", "k2"])
+        assert result["val"].to_list() == ["v1", "V2", "v3", "v4", "V_new", "V_new2"]
+
+
+# ---------------------------------------------------------------------------
+# MERGE: multi-file
+# ---------------------------------------------------------------------------
+
+
+class TestMergeMultiFile:
+    """Test merge across multiple data files."""
+
+    def test_merge_across_two_files(self, make_write_catalog):
+        """Merge where target spans two data files."""
+        cat = make_write_catalog()
+        df1 = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        df2 = pl.DataFrame({"id": [4, 5, 6], "val": ["d", "e", "f"]})
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
+
+        source = pl.DataFrame({"id": [2, 5, 7], "val": ["B", "E", "G"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+            when_not_matched_insert=True,
+        )
+        assert updated == 2
+        assert inserted == 1
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["id"].to_list() == [1, 2, 3, 4, 5, 6, 7]
+        assert result["val"].to_list() == ["a", "B", "c", "d", "E", "f", "G"]
+
+
+# ---------------------------------------------------------------------------
+# MERGE: time travel
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTimeTravel:
+    """Test time travel works after merge."""
+
+    def test_time_travel_before_after_merge(self, make_write_catalog):
+        """Read at snapshot before and after merge."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        snap_before = cat.query_one(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
+        )[0]
+
+        merge_ducklake(
+            cat.metadata_path, "test",
+            pl.DataFrame({"id": [2, 4], "val": ["B", "D"]}),
+            "id",
+            when_matched_update=True,
+        )
+
+        # Latest: merged
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["id"].to_list() == [1, 2, 3, 4]
+        assert result["val"].to_list() == ["a", "B", "c", "D"]
+
+        # Before merge: original
+        result_old = read_ducklake(
+            cat.metadata_path, "test", snapshot_version=snap_before
+        ).sort("id")
+        assert result_old["id"].to_list() == [1, 2, 3]
+        assert result_old["val"].to_list() == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# MERGE: DuckDB interop
+# ---------------------------------------------------------------------------
+
+
+class TestMergeDuckDBInterop:
+    """Verify merged catalogs are readable by DuckDB."""
+
+    def test_polars_merge_duckdb_reads(self, make_write_catalog):
+        """Write + merge with ducklake-polars, read with DuckDB."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        merge_ducklake(
+            cat.metadata_path, "test",
+            pl.DataFrame({"id": [2, 4], "val": ["B", "D"]}),
+            "id",
+            when_matched_update=True,
+        )
+
+        pdf = cat.read_with_duckdb("test").sort("id")
+        assert pdf["id"].to_list() == [1, 2, 3, 4]
+        assert pdf["val"].to_list() == ["a", "B", "c", "D"]
+
+    def test_duckdb_write_polars_merge_duckdb_reads(self, make_write_catalog):
+        """DuckDB creates data, polars merges, DuckDB reads result."""
+        cat = make_write_catalog()
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        if cat.backend == "sqlite":
+            attach_source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            attach_source = f"ducklake:postgres:{cat.metadata_path}"
+        con.execute(
+            f"ATTACH '{attach_source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE TABLE ducklake.test (id INTEGER, val VARCHAR)")
+        con.execute(
+            "INSERT INTO ducklake.test VALUES "
+            "(1, 'one'), (2, 'two'), (3, 'three')"
+        )
+        con.close()
+
+        # DuckDB INTEGER maps to Int32 in Parquet — source must match
+        source = pl.DataFrame({
+            "id": pl.Series([2, 3, 4], dtype=pl.Int32),
+            "val": ["TWO", "THREE", "FOUR"],
+        })
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+        )
+        assert updated == 2
+        assert inserted == 1
+
+        # Read with ducklake-polars
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["val"].to_list() == ["one", "TWO", "THREE", "FOUR"]
+
+        # Read with DuckDB
+        pdf = cat.read_with_duckdb("test").sort("id")
+        assert pdf["val"].to_list() == ["one", "TWO", "THREE", "FOUR"]
+
+    def test_create_table_as_duckdb_interop(self, make_write_catalog):
+        """DuckDB can read a table created via create_table_as, then polars can merge."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+        create_table_as_ducklake(df, cat.metadata_path, "test")
+
+        # Verify DuckDB can read
+        pdf = cat.read_with_duckdb("test").sort("id")
+        assert pdf["id"].to_list() == [1, 2]
+
+        # Now merge
+        source = pl.DataFrame({"id": [2, 3], "val": ["B", "C"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+        )
+        assert updated == 1
+        assert inserted == 1
+
+        # Both readers agree
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        pdf = cat.read_with_duckdb("test").sort("id")
+        assert result["val"].to_list() == ["a", "B", "C"]
+        assert pdf["val"].to_list() == ["a", "B", "C"]
+
+
+# ---------------------------------------------------------------------------
+# MERGE: metadata verification
+# ---------------------------------------------------------------------------
+
+
+class TestMergeMetadata:
+    """Verify merge metadata is correctly stored."""
+
+    def test_merge_creates_single_snapshot(self, make_write_catalog):
+        """Merge should create exactly one snapshot for the whole operation."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        snap_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+
+        merge_ducklake(
+            cat.metadata_path, "test",
+            pl.DataFrame({"id": [2, 4], "val": ["B", "D"]}),
+            "id",
+            when_matched_update=True,
+        )
+
+        snap_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+        assert snap_after == snap_before + 1
+
+    def test_merge_snapshot_changes(self, make_write_catalog):
+        """Changes record should have both insert and delete."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        merge_ducklake(
+            cat.metadata_path, "test",
+            pl.DataFrame({"id": [2, 4], "val": ["B", "D"]}),
+            "id",
+            when_matched_update=True,
+        )
+
+        row = cat.query_one(
+            "SELECT changes_made FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row is not None
+        assert "inserted_into_table" in row[0]
+        assert "deleted_from_table" in row[0]
+
+    def test_merge_delete_file_created(self, make_write_catalog):
+        """Merge with updates should create delete files for matched rows."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        merge_ducklake(
+            cat.metadata_path, "test",
+            pl.DataFrame({"id": [2], "val": ["B"]}),
+            "id",
+            when_matched_update=True,
+        )
+
+        # Should have 1 delete file for the matched row
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_delete_file")
+        assert row[0] >= 1
+
+        # Should have 2 data files: original + new insert
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_data_file")
+        assert row[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# MERGE: edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestMergeEdgeCases:
+    """Edge cases for the merge path."""
+
+    def test_merge_insert_only_no_update(self, make_write_catalog):
+        """when_matched_update=None, when_not_matched_insert=True."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [2, 3], "val": ["B", "C"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=None,
+            when_not_matched_insert=True,
+        )
+        assert updated == 0
+        assert inserted == 1
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["id"].to_list() == [1, 2, 3]
+        assert result["val"].to_list() == ["a", "b", "C"]
+
+    def test_merge_update_all_rows(self, make_write_catalog):
+        """Merge where all target rows match."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [1, 2, 3], "val": ["X", "Y", "Z"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+        )
+        assert updated == 3
+        assert inserted == 0
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["val"].to_list() == ["X", "Y", "Z"]
+
+    def test_merge_with_expr_update(self, make_write_catalog):
+        """Merge with expression-based dict update."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [2, 3], "val": [200, 300]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update={"val": pl.col("val") + 1000},
+            when_not_matched_insert=False,
+        )
+        assert updated == 2
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["val"].to_list() == [10, 1020, 1030]
+
+    def test_merge_preserves_unmatched_target(self, make_write_catalog):
+        """Unmatched target rows should remain unchanged."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2, 3, 4, 5], "val": ["a", "b", "c", "d", "e"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [3], "val": ["C"]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+            when_not_matched_insert=False,
+        )
+        assert updated == 1
+        assert inserted == 0
+
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
+        assert result["val"].to_list() == ["a", "b", "C", "d", "e"]
+
+    def test_scan_after_merge(self, make_write_catalog):
+        """scan_ducklake with filter after merge."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": list(range(1, 6)), "val": ["a"] * 5})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [3, 6], "val": ["MERGED", "MERGED"]})
+        merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+        )
+
+        result = (
+            scan_ducklake(cat.metadata_path, "test")
+            .filter(pl.col("val") == "MERGED")
+            .collect()
+            .sort("id")
+        )
+        assert result["id"].to_list() == [3, 6]
+
+    def test_merge_on_string_single_key(self, make_write_catalog):
+        """Merge with 'on' passed as a single string (not list)."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"key": ["a", "b"], "val": [1, 2]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"key": ["b", "c"], "val": [20, 30]})
+        updated, inserted = merge_ducklake(
+            cat.metadata_path, "test", source, "key",
+            when_matched_update=True,
+        )
+        assert updated == 1
+        assert inserted == 1
+
+        result = read_ducklake(cat.metadata_path, "test").sort("key")
+        assert result["key"].to_list() == ["a", "b", "c"]
+        assert result["val"].to_list() == [1, 20, 30]

--- a/tests/test_write_partition.py
+++ b/tests/test_write_partition.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import sqlite3
-
 import duckdb
 import polars as pl
 import pytest
@@ -20,47 +17,6 @@ from ducklake_polars import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_catalog(tmp_path):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "part_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name):
-    """Read a table with DuckDB's DuckLake extension."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
-# ---------------------------------------------------------------------------
 # ALTER TABLE SET PARTITIONED BY
 # ---------------------------------------------------------------------------
 
@@ -68,86 +24,82 @@ def _read_with_duckdb(metadata_path, data_path, table_name):
 class TestSetPartitionedBy:
     """Test alter_ducklake_set_partitioned_by."""
 
-    def test_set_partitioned_by_single_column(self, tmp_path):
+    def test_set_partitioned_by_single_column(self, make_write_catalog):
         """Set partitioning on a single column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
 
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         # Check metadata
-        con = sqlite3.connect(metadata_path)
-        pi = con.execute("SELECT partition_id, table_id FROM ducklake_partition_info").fetchone()
+        pi = cat.query_one("SELECT partition_id, table_id FROM ducklake_partition_info")
         assert pi is not None
         partition_id = pi[0]
 
-        pc = con.execute(
+        pc = cat.query_all(
             "SELECT partition_key_index, column_id, transform "
             "FROM ducklake_partition_column WHERE partition_id = ?",
             [partition_id],
-        ).fetchall()
+        )
         assert len(pc) == 1
         assert pc[0][0] == 0  # partition_key_index
         assert pc[0][2] == "identity"
 
         # Schema version bumped
-        change = con.execute(
+        change = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
+        )
         assert "altered_table" in change[0]
-        con.close()
 
-    def test_set_partitioned_by_multi_column(self, tmp_path):
+    def test_set_partitioned_by_multi_column(self, make_write_catalog):
         """Set partitioning on multiple columns."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"a": pl.Int64(), "b": pl.String(), "c": pl.Int64()},
         )
 
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b", "c"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b", "c"])
 
-        con = sqlite3.connect(metadata_path)
-        pcs = con.execute(
+        pcs = cat.query_all(
             "SELECT partition_key_index, transform "
             "FROM ducklake_partition_column ORDER BY partition_key_index"
-        ).fetchall()
+        )
         assert len(pcs) == 2
         assert pcs[0][0] == 0
         assert pcs[1][0] == 1
         assert pcs[0][1] == "identity"
         assert pcs[1][1] == "identity"
-        con.close()
 
-    def test_set_partitioned_by_nonexistent_table(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_set_partitioned_by_nonexistent_table(self, make_write_catalog):
+        cat = make_write_catalog()
         with pytest.raises(ValueError, match="not found"):
-            alter_ducklake_set_partitioned_by(metadata_path, "missing", ["a"])
+            alter_ducklake_set_partitioned_by(cat.metadata_path, "missing", ["a"])
 
-    def test_set_partitioned_by_nonexistent_column(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_set_partitioned_by_nonexistent_column(self, make_write_catalog):
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64()},
+            cat.metadata_path, "test", {"a": pl.Int64()},
         )
         with pytest.raises(ValueError, match="not found"):
-            alter_ducklake_set_partitioned_by(metadata_path, "test", ["missing"])
+            alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["missing"])
 
-    def test_set_partitioned_by_duckdb_reads(self, tmp_path):
+    def test_set_partitioned_by_duckdb_reads(self, make_write_catalog):
         """DuckDB can read the partition spec created by ducklake-polars."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         # Insert after partitioning
         df2 = pl.DataFrame({"a": [4, 5], "b": ["z", "x"]})
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 5
         assert sorted(pdf["a"].to_list()) == [1, 2, 3, 4, 5]
 
@@ -160,89 +112,82 @@ class TestSetPartitionedBy:
 class TestPartitionedInsert:
     """Test writing data to partitioned tables."""
 
-    def test_basic_partitioned_insert(self, tmp_path):
+    def test_basic_partitioned_insert(self, make_write_catalog):
         """Insert into a partitioned table creates per-partition files."""
-        metadata_path, data_path = _make_catalog(tmp_path)
-        schema = {"a": pl.Int32(), "b": pl.String()}
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["x", "y", "x"]
 
-    def test_partitioned_insert_hive_paths(self, tmp_path):
+    def test_partitioned_insert_hive_paths(self, make_write_catalog):
         """Verify Hive-style directory layout."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
         # Check data file paths in catalog
-        con = sqlite3.connect(metadata_path)
-        paths = con.execute(
+        paths = cat.query_all(
             "SELECT path FROM ducklake_data_file WHERE partition_id IS NOT NULL"
-        ).fetchall()
-        con.close()
+        )
 
         path_strs = [p[0] for p in paths]
         assert any("b=x/" in p for p in path_strs)
         assert any("b=y/" in p for p in path_strs)
 
-    def test_partitioned_insert_multi_column(self, tmp_path):
+    def test_partitioned_insert_multi_column(self, make_write_catalog):
         """Multi-column partition produces nested Hive paths."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"a": pl.Int64(), "b": pl.String(), "c": pl.Int64()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b", "c"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b", "c"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"], "c": [10, 20, 10]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["x", "y", "x"]
         assert result["c"].to_list() == [10, 20, 10]
 
         # Check nested paths
-        con = sqlite3.connect(metadata_path)
-        paths = con.execute(
+        paths = cat.query_all(
             "SELECT path FROM ducklake_data_file WHERE partition_id IS NOT NULL"
-        ).fetchall()
-        con.close()
+        )
 
         path_strs = [p[0] for p in paths]
         assert any("b=x/c=10/" in p for p in path_strs)
         assert any("b=y/c=20/" in p for p in path_strs)
 
-    def test_partitioned_insert_partition_values_registered(self, tmp_path):
+    def test_partitioned_insert_partition_values_registered(self, make_write_catalog):
         """Partition values are correctly registered in ducklake_file_partition_value."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        con = sqlite3.connect(metadata_path)
-        pvs = con.execute(
+        pvs = cat.query_all(
             "SELECT data_file_id, partition_key_index, partition_value "
             "FROM ducklake_file_partition_value ORDER BY data_file_id"
-        ).fetchall()
-        con.close()
+        )
 
         # Should have one entry per partition file
         assert len(pvs) >= 2
@@ -250,51 +195,47 @@ class TestPartitionedInsert:
         assert "x" in values
         assert "y" in values
 
-    def test_partitioned_insert_partition_id_on_files(self, tmp_path):
+    def test_partitioned_insert_partition_id_on_files(self, make_write_catalog):
         """Data files reference the correct partition_id."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        con = sqlite3.connect(metadata_path)
-        pi = con.execute(
+        pi = cat.query_one(
             "SELECT partition_id FROM ducklake_partition_info"
-        ).fetchone()
-        dfs = con.execute(
+        )
+        dfs = cat.query_all(
             "SELECT partition_id FROM ducklake_data_file WHERE partition_id IS NOT NULL"
-        ).fetchall()
-        con.close()
+        )
 
         # All partitioned files should reference the same partition_id
         for (part_id,) in dfs:
             assert part_id == pi[0]
 
-    def test_partitioned_insert_column_stats(self, tmp_path):
+    def test_partitioned_insert_column_stats(self, make_write_catalog):
         """Column statistics are computed per-partition file."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 5, 3], "b": ["x", "x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        con = sqlite3.connect(metadata_path)
         # Stats for partition b=x: min=1, max=5
         # Stats for partition b=y: min=3, max=3
-        stats = con.execute(
+        stats = cat.query_all(
             "SELECT data_file_id, column_id, min_value, max_value "
             "FROM ducklake_file_column_stats "
             "WHERE column_id = (SELECT column_id FROM ducklake_column WHERE column_name='a' LIMIT 1) "
             "ORDER BY data_file_id"
-        ).fetchall()
-        con.close()
+        )
 
         assert len(stats) >= 2
         mins = {s[2] for s in stats}
@@ -304,39 +245,39 @@ class TestPartitionedInsert:
         assert "5" in maxs
         assert "3" in maxs
 
-    def test_partitioned_insert_multiple_batches(self, tmp_path):
+    def test_partitioned_insert_multiple_batches(self, make_write_catalog):
         """Multiple inserts into a partitioned table append correctly."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         write_ducklake(
             pl.DataFrame({"a": [1, 2], "b": ["x", "y"]}),
-            metadata_path, "test", mode="append",
+            cat.metadata_path, "test", mode="append",
         )
         write_ducklake(
             pl.DataFrame({"a": [3, 4], "b": ["x", "z"]}),
-            metadata_path, "test", mode="append",
+            cat.metadata_path, "test", mode="append",
         )
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3, 4]
         assert result["b"].to_list() == ["x", "y", "x", "z"]
 
-    def test_partitioned_insert_integer_partition(self, tmp_path):
+    def test_partitioned_insert_integer_partition(self, make_write_catalog):
         """Partition on an integer column."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.Int64()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.Int64()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": [100, 200, 100]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == [100, 200, 100]
 
@@ -349,34 +290,34 @@ class TestPartitionedInsert:
 class TestPartitionedFilter:
     """Test filtering on partition columns after partitioned writes."""
 
-    def test_filter_on_partition_column(self, tmp_path):
+    def test_filter_on_partition_column(self, make_write_catalog):
         """Filter on partition column returns correct subset."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["x", "y", "x", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        lf = scan_ducklake(metadata_path, "test")
+        lf = scan_ducklake(cat.metadata_path, "test")
         result = lf.filter(pl.col("b") == "x").collect().sort("a")
         assert result["a"].to_list() == [1, 3]
         assert result["b"].to_list() == ["x", "x"]
 
-    def test_filter_on_non_partition_column(self, tmp_path):
+    def test_filter_on_non_partition_column(self, make_write_catalog):
         """Filter on non-partition column in partitioned table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 5, 3, 2], "b": ["x", "x", "y", "y"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        lf = scan_ducklake(metadata_path, "test")
+        lf = scan_ducklake(cat.metadata_path, "test")
         result = lf.filter(pl.col("a") > 2).collect().sort("a")
         assert result["a"].to_list() == [3, 5]
 
@@ -389,24 +330,24 @@ class TestPartitionedFilter:
 class TestPartitionedOverwrite:
     """Test overwrite on partitioned tables."""
 
-    def test_overwrite_partitioned(self, tmp_path):
+    def test_overwrite_partitioned(self, make_write_catalog):
         """Overwrite partitioned table replaces all data."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         write_ducklake(
             pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]}),
-            metadata_path, "test", mode="append",
+            cat.metadata_path, "test", mode="append",
         )
         write_ducklake(
             pl.DataFrame({"a": [10, 20], "b": ["z", "w"]}),
-            metadata_path, "test", mode="overwrite",
+            cat.metadata_path, "test", mode="overwrite",
         )
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [10, 20]
         assert result["b"].to_list() == ["z", "w"]
 
@@ -419,50 +360,54 @@ class TestPartitionedOverwrite:
 class TestPartitionedDuckDBInterop:
     """DuckDB can read partitioned data written by ducklake-polars."""
 
-    def test_duckdb_reads_polars_partitioned_insert(self, tmp_path):
+    def test_duckdb_reads_polars_partitioned_insert(self, make_write_catalog):
         """DuckDB reads data written by ducklake-polars into partitioned table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 3
         assert sorted(pdf["a"].to_list()) == [1, 2, 3]
         assert sorted(pdf["b"].to_list()) == ["x", "x", "y"]
 
-    def test_duckdb_reads_polars_multi_partition(self, tmp_path):
+    def test_duckdb_reads_polars_multi_partition(self, make_write_catalog):
         """DuckDB reads multi-column partitioned data."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"a": pl.Int64(), "b": pl.String(), "c": pl.Int64()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b", "c"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b", "c"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"], "c": [10, 20, 10]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         assert len(pdf) == 3
         assert sorted(pdf["a"].to_list()) == [1, 2, 3]
 
-    def test_duckdb_writes_polars_reads_partitioned(self, tmp_path):
+    def test_duckdb_writes_polars_reads_partitioned(self, make_write_catalog):
         """DuckDB creates partitioned table, ducklake-polars writes to it."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        # Use DuckDB to create partitioned table structure
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
         con.execute("ALTER TABLE ducklake.test SET PARTITIONED BY (b)")
@@ -470,24 +415,28 @@ class TestPartitionedDuckDBInterop:
 
         # Insert via ducklake-polars (cast to Int32 to match DuckDB's INTEGER)
         df = pl.DataFrame({"a": pl.Series([1, 2, 3], dtype=pl.Int32), "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["x", "y", "x"]
 
-    def test_duckdb_insert_then_polars_insert_partitioned(self, tmp_path):
+    def test_duckdb_insert_then_polars_insert_partitioned(self, make_write_catalog):
         """DuckDB inserts data, then ducklake-polars appends to same partitioned table."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
+
+        # Use DuckDB to create table, partition, and insert initial data
+        if cat.backend == "sqlite":
+            source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            source = f"ducklake:postgres:{cat.metadata_path}"
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
         con.execute("ALTER TABLE ducklake.test SET PARTITIONED BY (b)")
@@ -496,9 +445,9 @@ class TestPartitionedDuckDBInterop:
 
         # Append via ducklake-polars (cast to Int32 to match DuckDB's INTEGER)
         df = pl.DataFrame({"a": pl.Series([3, 4], dtype=pl.Int32), "b": ["x", "z"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3, 4]
         assert result["b"].to_list() == ["x", "y", "x", "z"]
 
@@ -511,16 +460,16 @@ class TestPartitionedDuckDBInterop:
 class TestPartitionedRoundTrip:
     """Write and read partitioned data with ducklake-polars."""
 
-    def test_roundtrip_basic(self, tmp_path):
-        metadata_path, data_path = _make_catalog(tmp_path)
+    def test_roundtrip_basic(self, make_write_catalog):
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "id": [1, 2, 3, 4, 5],
             "category": ["a", "b", "a", "b", "c"],
             "value": [10.0, 20.0, 30.0, 40.0, 50.0],
         })
 
-        write_ducklake(df, metadata_path, "test", mode="error")
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["category"])
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["category"])
 
         # Insert more data
         df2 = pl.DataFrame({
@@ -528,44 +477,42 @@ class TestPartitionedRoundTrip:
             "category": ["a", "d"],
             "value": [60.0, 70.0],
         })
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("id")
+        result = read_ducklake(cat.metadata_path, "test").sort("id")
         assert result["id"].to_list() == [1, 2, 3, 4, 5, 6, 7]
         assert result["category"].to_list() == ["a", "b", "a", "b", "c", "a", "d"]
         assert result["value"].to_list() == [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0]
 
-    def test_roundtrip_time_travel(self, tmp_path):
+    def test_roundtrip_time_travel(self, make_write_catalog):
         """Time travel works with partitioned writes."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         write_ducklake(
             pl.DataFrame({"a": [1, 2], "b": ["x", "y"]}),
-            metadata_path, "test", mode="append",
+            cat.metadata_path, "test", mode="append",
         )
 
-        con = sqlite3.connect(metadata_path)
-        snap_after_first = con.execute(
+        snap_after_first = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )[0]
 
         write_ducklake(
             pl.DataFrame({"a": [3, 4], "b": ["x", "z"]}),
-            metadata_path, "test", mode="append",
+            cat.metadata_path, "test", mode="append",
         )
 
         # Latest: 4 rows
-        result = read_ducklake(metadata_path, "test")
+        result = read_ducklake(cat.metadata_path, "test")
         assert result.shape[0] == 4
 
         # At first insert: 2 rows
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_after_first
+            cat.metadata_path, "test", snapshot_version=snap_after_first
         )
         assert result_old.shape[0] == 2
         result_old = result_old.sort("a")
@@ -580,22 +527,22 @@ class TestPartitionedRoundTrip:
 class TestPartitionedDelete:
     """Test DELETE on partitioned tables written by ducklake-polars."""
 
-    def test_delete_from_partitioned(self, tmp_path):
+    def test_delete_from_partitioned(self, make_write_catalog):
         from ducklake_polars import delete_ducklake
 
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
-        deleted = delete_ducklake(metadata_path, "test", pl.col("a") == 1)
+        deleted = delete_ducklake(cat.metadata_path, "test", pl.col("a") == 1)
         assert deleted == 1
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [2, 3]
         assert result["b"].to_list() == ["y", "x"]
 
@@ -608,24 +555,24 @@ class TestPartitionedDelete:
 class TestPartitionedUpdate:
     """Test UPDATE on partitioned tables written by ducklake-polars."""
 
-    def test_update_non_partition_column(self, tmp_path):
+    def test_update_non_partition_column(self, make_write_catalog):
         from ducklake_polars import update_ducklake
 
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         create_ducklake_table(
-            metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
+            cat.metadata_path, "test", {"a": pl.Int64(), "b": pl.String()},
         )
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df, metadata_path, "test", mode="append")
+        write_ducklake(df, cat.metadata_path, "test", mode="append")
 
         updated = update_ducklake(
-            metadata_path, "test", {"a": 10}, pl.col("a") == 1
+            cat.metadata_path, "test", {"a": 10}, pl.col("a") == 1
         )
         assert updated == 1
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [2, 3, 10]
         assert result["b"].to_list() == ["y", "x", "x"]
 
@@ -638,33 +585,33 @@ class TestPartitionedUpdate:
 class TestWriteModeWithPartition:
     """Test write_ducklake modes combined with partitioning."""
 
-    def test_mode_error_then_partition_then_append(self, tmp_path):
+    def test_mode_error_then_partition_then_append(self, make_write_catalog):
         """Create with mode='error', partition, then append."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         df1 = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-        write_ducklake(df1, metadata_path, "test", mode="error")
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         df2 = pl.DataFrame({"a": [3, 4], "b": ["x", "z"]})
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3, 4]
         assert result["b"].to_list() == ["x", "y", "x", "z"]
 
-    def test_mode_overwrite_on_partitioned(self, tmp_path):
+    def test_mode_overwrite_on_partitioned(self, make_write_catalog):
         """mode='overwrite' on partitioned table."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
 
         df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-        write_ducklake(df1, metadata_path, "test", mode="error")
-        alter_ducklake_set_partitioned_by(metadata_path, "test", ["b"])
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
+        alter_ducklake_set_partitioned_by(cat.metadata_path, "test", ["b"])
 
         # Overwrite with different partition values
         df2 = pl.DataFrame({"a": [10, 20], "b": ["p", "q"]})
-        write_ducklake(df2, metadata_path, "test", mode="overwrite")
+        write_ducklake(df2, cat.metadata_path, "test", mode="overwrite")
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [10, 20]
         assert result["b"].to_list() == ["p", "q"]

--- a/tests/test_write_update.py
+++ b/tests/test_write_update.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-import os
-import sqlite3
-
 import duckdb
 import polars as pl
-import pytest
-from polars.testing import assert_frame_equal
 
 from ducklake_polars import (
     read_ducklake,
@@ -19,47 +14,6 @@ from ducklake_polars import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_catalog(tmp_path):
-    """Create a DuckLake catalog via DuckDB and return (metadata_path, data_path)."""
-    metadata_path = str(tmp_path / "update_test.ducklake")
-    data_path = str(tmp_path / "data")
-    os.makedirs(data_path, exist_ok=True)
-
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    con.close()
-    return metadata_path, data_path
-
-
-def _read_with_duckdb(metadata_path, data_path, table_name):
-    """Read a table with DuckDB's DuckLake extension."""
-    con = duckdb.connect()
-    con.install_extension("ducklake")
-    con.load_extension("ducklake")
-    con.execute(
-        f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-        f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
-    )
-    cursor = con.execute(f'SELECT * FROM ducklake."{table_name}"')
-    columns = [desc[0] for desc in cursor.description]
-    rows = cursor.fetchall()
-    con.close()
-    if not rows:
-        return pl.DataFrame({c: [] for c in columns})
-    data = {c: [r[i] for r in rows] for i, c in enumerate(columns)}
-    return pl.DataFrame(data)
-
-
-# ---------------------------------------------------------------------------
 # Basic update operations
 # ---------------------------------------------------------------------------
 
@@ -67,98 +21,96 @@ def _read_with_duckdb(metadata_path, data_path, table_name):
 class TestUpdateBasic:
     """Test basic update operations."""
 
-    def test_update_single_column_literal(self, tmp_path):
+    def test_update_single_column_literal(self, make_write_catalog):
         """Update a single column to a literal value."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": [1, 2, 3, 4, 5],
             "b": ["one", "two", "three", "four", "five"],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         updated = update_ducklake(
-            metadata_path, "test", {"b": "UPDATED"}, pl.col("a") > 3
+            cat.metadata_path, "test", {"b": "UPDATED"}, pl.col("a") > 3
         )
         assert updated == 2
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3, 4, 5]
         assert result["b"].to_list() == ["one", "two", "three", "UPDATED", "UPDATED"]
 
-    def test_update_multiple_columns(self, tmp_path):
+    def test_update_multiple_columns(self, make_write_catalog):
         """Update multiple columns at once."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": [1, 2, 3],
             "b": ["x", "y", "z"],
             "c": [10.0, 20.0, 30.0],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         updated = update_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"b": "NEW", "c": 99.0},
             pl.col("a") == 2,
         )
         assert updated == 1
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["b"].to_list() == ["x", "NEW", "z"]
         assert result["c"].to_list() == [10.0, 99.0, 30.0]
 
-    def test_update_with_expression(self, tmp_path):
+    def test_update_with_expression(self, make_write_catalog):
         """Update using a Polars expression (computed value)."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": [1, 2, 3, 4, 5],
             "b": ["one", "two", "three", "four", "five"],
             "c": [1.0, 2.0, 3.0, 4.0, 5.0],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         updated = update_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"c": pl.col("c") + 100.0, "b": "UPDATED"},
             pl.col("a") >= 3,
         )
         assert updated == 3
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["c"].to_list() == [1.0, 2.0, 103.0, 104.0, 105.0]
         assert result["b"].to_list() == ["one", "two", "UPDATED", "UPDATED", "UPDATED"]
 
-    def test_update_no_matching_rows(self, tmp_path):
+    def test_update_no_matching_rows(self, make_write_catalog):
         """Update with no matching rows creates no snapshot."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute("SELECT COUNT(*) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_snapshot")
+        snap_before = row[0]
 
         updated = update_ducklake(
-            metadata_path, "test", {"a": 99}, pl.col("a") > 100
+            cat.metadata_path, "test", {"a": 99}, pl.col("a") > 100
         )
         assert updated == 0
 
-        con = sqlite3.connect(metadata_path)
-        snap_after = con.execute("SELECT COUNT(*) FROM ducklake_snapshot").fetchone()[0]
-        con.close()
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_snapshot")
+        snap_after = row[0]
         assert snap_after == snap_before
 
-    def test_update_all_rows(self, tmp_path):
+    def test_update_all_rows(self, make_write_catalog):
         """Update all rows."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         updated = update_ducklake(
-            metadata_path, "test", {"b": "ALL"}, pl.lit(True)
+            cat.metadata_path, "test", {"b": "ALL"}, pl.lit(True)
         )
         assert updated == 3
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 3]
         assert result["b"].to_list() == ["ALL", "ALL", "ALL"]
 
@@ -171,37 +123,37 @@ class TestUpdateBasic:
 class TestUpdateMultiFile:
     """Test updates spanning multiple data files."""
 
-    def test_update_across_multiple_files(self, tmp_path):
+    def test_update_across_multiple_files(self, make_write_catalog):
         """Two inserts (two files), update rows from both."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         df2 = pl.DataFrame({"a": [4, 5, 6], "b": ["p", "q", "r"]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
         # Update even numbers from both files
         updated = update_ducklake(
-            metadata_path, "test", {"b": "EVEN"}, pl.col("a") % 2 == 0
+            cat.metadata_path, "test", {"b": "EVEN"}, pl.col("a") % 2 == 0
         )
         assert updated == 3
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["b"].to_list() == ["x", "EVEN", "z", "EVEN", "q", "EVEN"]
 
-    def test_update_one_of_two_files(self, tmp_path):
+    def test_update_one_of_two_files(self, make_write_catalog):
         """Two files, update only affects one."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         df2 = pl.DataFrame({"a": [100, 200], "b": ["p", "q"]})
-        write_ducklake(df1, metadata_path, "test", mode="append")
-        write_ducklake(df2, metadata_path, "test", mode="append")
+        write_ducklake(df1, cat.metadata_path, "test", mode="append")
+        write_ducklake(df2, cat.metadata_path, "test", mode="append")
 
         updated = update_ducklake(
-            metadata_path, "test", {"b": "BIG"}, pl.col("a") >= 100
+            cat.metadata_path, "test", {"b": "BIG"}, pl.col("a") >= 100
         )
         assert updated == 2
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["b"].to_list() == ["x", "y", "z", "BIG", "BIG"]
 
 
@@ -213,27 +165,26 @@ class TestUpdateMultiFile:
 class TestUpdateTimeTravel:
     """Test time travel with updates."""
 
-    def test_time_travel_before_after_update(self, tmp_path):
+    def test_time_travel_before_after_update(self, make_write_catalog):
         """Read at snapshot before and after update."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        con = sqlite3.connect(metadata_path)
-        snap_before = con.execute(
+        row = cat.query_one(
             "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
-        ).fetchone()[0]
-        con.close()
+        )
+        snap_before = row[0]
 
-        update_ducklake(metadata_path, "test", {"b": "NEW"}, pl.col("a") == 2)
+        update_ducklake(cat.metadata_path, "test", {"b": "NEW"}, pl.col("a") == 2)
 
         # Latest: updated
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["b"].to_list() == ["x", "NEW", "z"]
 
         # Before update: original
         result_old = read_ducklake(
-            metadata_path, "test", snapshot_version=snap_before
+            cat.metadata_path, "test", snapshot_version=snap_before
         ).sort("a")
         assert result_old["b"].to_list() == ["x", "y", "z"]
 
@@ -246,31 +197,33 @@ class TestUpdateTimeTravel:
 class TestUpdateDuckDBInterop:
     """Verify updated catalogs are readable by DuckDB."""
 
-    def test_polars_update_duckdb_reads(self, tmp_path):
+    def test_polars_update_duckdb_reads(self, make_write_catalog):
         """Write + update with ducklake-polars, read with DuckDB."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        update_ducklake(metadata_path, "test", {"b": "UPDATED"}, pl.col("a") > 1)
+        update_ducklake(cat.metadata_path, "test", {"b": "UPDATED"}, pl.col("a") > 1)
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test")
+        pdf = cat.read_with_duckdb("test")
         pdf = pdf.sort("a")
         assert pdf["a"].to_list() == [1, 2, 3]
         assert pdf["b"].to_list() == ["x", "UPDATED", "UPDATED"]
 
-    def test_duckdb_write_polars_update_duckdb_reads(self, tmp_path):
+    def test_duckdb_write_polars_update_duckdb_reads(self, make_write_catalog):
         """DuckDB creates data, polars updates, DuckDB reads result."""
-        metadata_path = str(tmp_path / "test.ducklake")
-        data_path = str(tmp_path / "data")
-        os.makedirs(data_path, exist_ok=True)
+        cat = make_write_catalog()
 
         con = duckdb.connect()
         con.install_extension("ducklake")
         con.load_extension("ducklake")
+        if cat.backend == "sqlite":
+            attach_source = f"ducklake:sqlite:{cat.metadata_path}"
+        else:
+            attach_source = f"ducklake:postgres:{cat.metadata_path}"
         con.execute(
-            f"ATTACH 'ducklake:sqlite:{metadata_path}' AS ducklake "
-            f"(DATA_PATH '{data_path}', DATA_INLINING_ROW_LIMIT 0)"
+            f"ATTACH '{attach_source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
         )
         con.execute("CREATE TABLE ducklake.test (a INTEGER, b VARCHAR)")
         con.execute(
@@ -280,31 +233,31 @@ class TestUpdateDuckDBInterop:
         con.close()
 
         updated = update_ducklake(
-            metadata_path, "test", {"b": "CHANGED"}, pl.col("a") >= 2
+            cat.metadata_path, "test", {"b": "CHANGED"}, pl.col("a") >= 2
         )
         assert updated == 2
 
         # Read with ducklake-polars
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["b"].to_list() == ["one", "CHANGED", "CHANGED"]
 
         # Read with DuckDB
-        pdf = _read_with_duckdb(metadata_path, data_path, "test").sort("a")
+        pdf = cat.read_with_duckdb("test").sort("a")
         assert pdf["b"].to_list() == ["one", "CHANGED", "CHANGED"]
 
-    def test_update_with_expression_duckdb_reads(self, tmp_path):
+    def test_update_with_expression_duckdb_reads(self, make_write_catalog):
         """Expression-based update readable by DuckDB."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "val": [10.0, 20.0, 30.0]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         update_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"val": pl.col("val") * 2},
             pl.col("a") >= 2,
         )
 
-        pdf = _read_with_duckdb(metadata_path, data_path, "test").sort("a")
+        pdf = cat.read_with_duckdb("test").sort("a")
         assert pdf["val"].to_list() == [10.0, 40.0, 60.0]
 
 
@@ -316,55 +269,49 @@ class TestUpdateDuckDBInterop:
 class TestUpdateMetadata:
     """Verify update metadata is correctly stored."""
 
-    def test_snapshot_changes_has_both_ops(self, tmp_path):
+    def test_snapshot_changes_has_both_ops(self, make_write_catalog):
         """Check that changes_made has both inserted and deleted."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        update_ducklake(metadata_path, "test", {"a": 99}, pl.col("a") == 2)
+        update_ducklake(cat.metadata_path, "test", {"a": 99}, pl.col("a") == 2)
 
-        con = sqlite3.connect(metadata_path)
-        row = con.execute(
+        row = cat.query_one(
             "SELECT changes_made FROM ducklake_snapshot_changes "
             "ORDER BY snapshot_id DESC LIMIT 1"
-        ).fetchone()
-        con.close()
+        )
 
         assert row is not None
         assert "inserted_into_table" in row[0]
         assert "deleted_from_table" in row[0]
 
-    def test_update_creates_delete_and_data_file(self, tmp_path):
+    def test_update_creates_delete_and_data_file(self, make_write_catalog):
         """One delete file and one new data file should be created."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        update_ducklake(metadata_path, "test", {"b": "NEW"}, pl.col("a") == 2)
-
-        con = sqlite3.connect(metadata_path)
+        update_ducklake(cat.metadata_path, "test", {"b": "NEW"}, pl.col("a") == 2)
 
         # Should have 2 data files total (original + updated)
-        data_files = con.execute(
+        row = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_data_file"
-        ).fetchone()[0]
-        assert data_files == 2
+        )
+        assert row[0] == 2
 
         # Should have 1 delete file
-        delete_files = con.execute(
+        row = cat.query_one(
             "SELECT COUNT(*) FROM ducklake_delete_file"
-        ).fetchone()[0]
-        assert delete_files == 1
+        )
+        assert row[0] == 1
 
         # New data file should have 1 row (the updated row)
-        new_data = con.execute(
+        row = cat.query_one(
             "SELECT record_count FROM ducklake_data_file "
             "ORDER BY data_file_id DESC LIMIT 1"
-        ).fetchone()
-        assert new_data[0] == 1
-
-        con.close()
+        )
+        assert row[0] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -375,73 +322,73 @@ class TestUpdateMetadata:
 class TestUpdateEdgeCases:
     """Edge cases for the update path."""
 
-    def test_update_preserves_unmatched_rows(self, tmp_path):
+    def test_update_preserves_unmatched_rows(self, make_write_catalog):
         """Rows not matching the predicate are unchanged."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        update_ducklake(metadata_path, "test", {"a": 0}, pl.col("a") == 3)
+        update_ducklake(cat.metadata_path, "test", {"a": 0}, pl.col("a") == 3)
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [0, 1, 2, 4, 5]
 
-    def test_update_then_read_columns(self, tmp_path):
+    def test_update_then_read_columns(self, make_write_catalog):
         """Column selection works after update."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"], "c": [10, 20]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        update_ducklake(metadata_path, "test", {"b": "NEW"}, pl.col("a") == 1)
+        update_ducklake(cat.metadata_path, "test", {"b": "NEW"}, pl.col("a") == 1)
 
-        result = read_ducklake(metadata_path, "test", columns=["a", "b"]).sort("a")
+        result = read_ducklake(cat.metadata_path, "test", columns=["a", "b"]).sort("a")
         assert result.columns == ["a", "b"]
         assert result["b"].to_list() == ["NEW", "y"]
 
-    def test_update_with_null_value(self, tmp_path):
+    def test_update_with_null_value(self, make_write_catalog):
         """Update a column to NULL."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({
             "a": [1, 2, 3],
             "b": ["x", "y", "z"],
         })
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         update_ducklake(
-            metadata_path, "test",
+            cat.metadata_path, "test",
             {"b": pl.lit(None, dtype=pl.String)},
             pl.col("a") == 2,
         )
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["b"].to_list() == ["x", None, "z"]
 
-    def test_update_then_delete(self, tmp_path):
+    def test_update_then_delete(self, make_write_catalog):
         """Update followed by delete."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
-        update_ducklake(metadata_path, "test", {"a": 99}, pl.col("a") == 3)
+        update_ducklake(cat.metadata_path, "test", {"a": 99}, pl.col("a") == 3)
 
         from ducklake_polars import delete_ducklake
-        delete_ducklake(metadata_path, "test", pl.col("a") > 50)
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") > 50)
 
-        result = read_ducklake(metadata_path, "test").sort("a")
+        result = read_ducklake(cat.metadata_path, "test").sort("a")
         assert result["a"].to_list() == [1, 2, 4, 5]
 
-    def test_scan_after_update(self, tmp_path):
+    def test_scan_after_update(self, make_write_catalog):
         """scan_ducklake with filter after update."""
-        metadata_path, data_path = _make_catalog(tmp_path)
+        cat = make_write_catalog()
         df = pl.DataFrame({"a": list(range(10)), "b": ["x"] * 10})
-        write_ducklake(df, metadata_path, "test", mode="error")
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
 
         update_ducklake(
-            metadata_path, "test", {"b": "UPDATED"}, pl.col("a") >= 5
+            cat.metadata_path, "test", {"b": "UPDATED"}, pl.col("a") >= 5
         )
 
         result = (
-            scan_ducklake(metadata_path, "test")
+            scan_ducklake(cat.metadata_path, "test")
             .filter(pl.col("b") == "UPDATED")
             .collect()
             .sort("a")


### PR DESCRIPTION
## PR 5: PostgreSQL Write Backend

### Changes
- `PostgresBackend.connect_writable()` — writable psycopg2 connection
- `DuckLakeCatalogWriter` auto-detects backend type, uses `%s` placeholders for PostgreSQL
- All write tests parametrized over SQLite + PostgreSQL via `conftest.py` fixtures
- PostgreSQL tests skip when `DUCKLAKE_PG_DSN` not set (CI has it)

### Tests
- 522 tests passing
- Every write test now runs against both backends in CI