### PR TITLE
feat: Catalog maintenance — expire_snapshots, vacuum, commit metadata

### DIFF
--- a/src/ducklake_polars/__init__.py
+++ b/src/ducklake_polars/__init__.py
@@ -30,6 +30,8 @@ __all__ = [
     "create_ducklake_schema",
     "drop_ducklake_schema",
     "rename_ducklake_table",
+    "expire_snapshots",
+    "vacuum_ducklake",
     "DuckLakeCatalog",
 ]
 
@@ -162,6 +164,8 @@ def write_ducklake(
     mode: str = "error",
     data_path: str | Path | None = None,
     data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Write a Polars DataFrame to a DuckLake table.
@@ -211,6 +215,8 @@ def write_ducklake(
         metadata_path,
         data_path_override=dp,
         data_inlining_row_limit=data_inlining_row_limit,
+        author=author,
+        commit_message=commit_message,
     ) as writer:
         snap_id, _sv, _nci, _nfi = writer._get_latest_snapshot()
         table_id = writer._table_exists(table, schema, snap_id)
@@ -245,6 +251,8 @@ def create_ducklake_table(
     *,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Create a new table in a DuckLake catalog.
@@ -273,7 +281,10 @@ def create_ducklake_table(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.create_table(table, polars_schema, schema_name=schema)
 
 
@@ -285,6 +296,8 @@ def delete_ducklake(
     schema: str = "main",
     data_path: str | Path | None = None,
     data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> int:
     """
     Delete rows matching a predicate from a DuckLake table.
@@ -326,6 +339,8 @@ def delete_ducklake(
         metadata_path,
         data_path_override=dp,
         data_inlining_row_limit=data_inlining_row_limit,
+        author=author,
+        commit_message=commit_message,
     ) as writer:
         return writer.delete_data(predicate, table, schema_name=schema)
 
@@ -339,6 +354,8 @@ def update_ducklake(
     schema: str = "main",
     data_path: str | Path | None = None,
     data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> int:
     """
     Update rows matching a predicate in a DuckLake table.
@@ -381,6 +398,8 @@ def update_ducklake(
         metadata_path,
         data_path_override=dp,
         data_inlining_row_limit=data_inlining_row_limit,
+        author=author,
+        commit_message=commit_message,
     ) as writer:
         return writer.update_data(updates, predicate, table, schema_name=schema)
 
@@ -396,6 +415,8 @@ def merge_ducklake(
     schema: str = "main",
     data_path: str | Path | None = None,
     data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> tuple[int, int]:
     """
     Merge a source DataFrame into an existing DuckLake table.
@@ -444,6 +465,8 @@ def merge_ducklake(
         metadata_path,
         data_path_override=dp,
         data_inlining_row_limit=data_inlining_row_limit,
+        author=author,
+        commit_message=commit_message,
     ) as writer:
         return writer.merge_data(
             source_df,
@@ -463,6 +486,8 @@ def create_table_as_ducklake(
     schema: str = "main",
     data_path: str | Path | None = None,
     data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Create a new table and insert data in a single snapshot.
@@ -501,6 +526,8 @@ def create_table_as_ducklake(
         metadata_path,
         data_path_override=dp,
         data_inlining_row_limit=data_inlining_row_limit,
+        author=author,
+        commit_message=commit_message,
     ) as writer:
         writer.create_table_with_data(table, df, schema_name=schema)
 
@@ -514,6 +541,8 @@ def alter_ducklake_add_column(
     default: object = None,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Add a column to a DuckLake table.
@@ -547,7 +576,10 @@ def alter_ducklake_add_column(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.add_column(table, col_name, dtype, default=default, schema_name=schema)
 
 
@@ -558,6 +590,8 @@ def alter_ducklake_drop_column(
     *,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Drop a column from a DuckLake table.
@@ -586,7 +620,10 @@ def alter_ducklake_drop_column(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.drop_column(table, col_name, schema_name=schema)
 
 
@@ -598,6 +635,8 @@ def alter_ducklake_rename_column(
     *,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Rename a column in a DuckLake table.
@@ -629,7 +668,10 @@ def alter_ducklake_rename_column(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.rename_column(
             table, old_col_name, new_col_name, schema_name=schema
         )
@@ -641,6 +683,8 @@ def drop_ducklake_table(
     *,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Drop a table from a DuckLake catalog.
@@ -667,7 +711,10 @@ def drop_ducklake_table(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.drop_table(table, schema_name=schema)
 
 
@@ -676,6 +723,8 @@ def create_ducklake_schema(
     schema_name: str,
     *,
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Create a new schema in a DuckLake catalog.
@@ -700,7 +749,10 @@ def create_ducklake_schema(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.create_schema(schema_name)
 
 
@@ -710,6 +762,8 @@ def drop_ducklake_schema(
     *,
     cascade: bool = False,
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Drop a schema from a DuckLake catalog.
@@ -737,7 +791,10 @@ def drop_ducklake_schema(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.drop_schema(schema_name, cascade=cascade)
 
 
@@ -748,6 +805,8 @@ def rename_ducklake_table(
     *,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Rename a table in a DuckLake catalog.
@@ -776,7 +835,10 @@ def rename_ducklake_table(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.rename_table(old_table, new_table, schema_name=schema)
 
 
@@ -787,6 +849,8 @@ def alter_ducklake_set_partitioned_by(
     *,
     schema: str = "main",
     data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
 ) -> None:
     """
     Set identity-transform partitioning on a DuckLake table.
@@ -819,5 +883,90 @@ def alter_ducklake_set_partitioned_by(
     metadata_path = os.fspath(path)
     dp = os.fspath(data_path) if data_path is not None else None
 
-    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+    with DuckLakeCatalogWriter(
+        metadata_path, data_path_override=dp,
+        author=author, commit_message=commit_message,
+    ) as writer:
         writer.set_partitioned_by(table, columns, schema_name=schema)
+
+
+def expire_snapshots(
+    path: str | Path,
+    *,
+    older_than_snapshot: int | None = None,
+    keep_last_n: int | None = None,
+    data_path: str | Path | None = None,
+) -> int:
+    """
+    Expire old snapshots and clean up associated metadata.
+
+    Removes snapshot rows, snapshot_changes entries, and metadata
+    entries (data files, delete files, column stats, partition values)
+    whose ``end_snapshot`` falls within the expired range. This is a
+    metadata-only operation — call :func:`vacuum_ducklake` afterwards
+    to delete the actual orphaned Parquet files.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Supports SQLite and PostgreSQL backends.
+    older_than_snapshot
+        Expire all snapshots with ``snapshot_id < older_than_snapshot``.
+    keep_last_n
+        Keep the most recent *n* snapshots, expire the rest.
+        Cannot be combined with *older_than_snapshot*.
+    data_path
+        Override the data path stored in the catalog.
+
+    Returns
+    -------
+    int
+        The number of snapshots expired.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        return writer.expire_snapshots(
+            older_than_snapshot=older_than_snapshot,
+            keep_last_n=keep_last_n,
+        )
+
+
+def vacuum_ducklake(
+    path: str | Path,
+    *,
+    data_path: str | Path | None = None,
+) -> int:
+    """
+    Delete orphaned Parquet files not referenced by any catalog entry.
+
+    Scans the data directory for all ``.parquet`` files and removes
+    those that are not referenced by any ``ducklake_data_file`` or
+    ``ducklake_delete_file`` entry in the catalog. Run
+    :func:`expire_snapshots` first to clean up metadata for old
+    snapshots, then call this to reclaim disk space.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Supports SQLite and PostgreSQL backends.
+    data_path
+        Override the data path stored in the catalog.
+
+    Returns
+    -------
+    int
+        The number of Parquet files deleted.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(metadata_path, data_path_override=dp) as writer:
+        return writer.vacuum()

--- a/src/ducklake_polars/_writer.py
+++ b/src/ducklake_polars/_writer.py
@@ -123,11 +123,15 @@ class DuckLakeCatalogWriter:
         *,
         data_path_override: str | None = None,
         data_inlining_row_limit: int = 0,
+        author: str | None = None,
+        commit_message: str | None = None,
     ) -> None:
         self._backend = create_backend(metadata_path)
         self._metadata_path = metadata_path
         self._data_path_override = data_path_override
         self._data_inlining_row_limit = data_inlining_row_limit
+        self._author = author
+        self._commit_message = commit_message
         self._con: Any = None
 
     def _connect(self) -> Any:
@@ -189,13 +193,17 @@ class DuckLakeCatalogWriter:
         snapshot_id: int,
         changes_made: str,
     ) -> None:
-        """Insert a snapshot_changes record."""
+        """Insert a snapshot_changes record.
+
+        Uses the ``author`` and ``commit_message`` stored on the writer
+        instance (set via the constructor).
+        """
         con = self._connect()
         con.execute(
             "INSERT INTO ducklake_snapshot_changes "
             "(snapshot_id, changes_made, author, commit_message, commit_extra_info) "
-            "VALUES (?, ?, NULL, NULL, NULL)",
-            [snapshot_id, changes_made],
+            "VALUES (?, ?, ?, ?, NULL)",
+            [snapshot_id, changes_made, self._author, self._commit_message],
         )
 
     # ------------------------------------------------------------------
@@ -3245,3 +3253,232 @@ class DuckLakeCatalogWriter:
         self._record_change(new_snap, f"altered_table:{table_id}")
 
         con.commit()
+
+    # ------------------------------------------------------------------
+    # EXPIRE SNAPSHOTS
+    # ------------------------------------------------------------------
+
+    def expire_snapshots(
+        self,
+        *,
+        older_than_snapshot: int | None = None,
+        keep_last_n: int | None = None,
+    ) -> int:
+        """Expire old snapshots and clean up associated metadata.
+
+        Removes snapshot rows, snapshot_changes entries, and metadata
+        entries (data files, delete files, column stats, partition
+        values) whose ``end_snapshot`` falls within the expired range.
+        This is a metadata-only operation — actual Parquet file deletion
+        is handled by :meth:`vacuum`.
+
+        Parameters
+        ----------
+        older_than_snapshot
+            Expire all snapshots with ``snapshot_id < older_than_snapshot``.
+        keep_last_n
+            Keep the most recent *n* snapshots, expire the rest.
+            Cannot be combined with *older_than_snapshot*.
+
+        Returns
+        -------
+        int
+            The number of snapshots expired.
+        """
+        if older_than_snapshot is not None and keep_last_n is not None:
+            msg = "Cannot specify both older_than_snapshot and keep_last_n"
+            raise ValueError(msg)
+        if older_than_snapshot is None and keep_last_n is None:
+            msg = "Must specify either older_than_snapshot or keep_last_n"
+            raise ValueError(msg)
+
+        con = self._connect()
+
+        # Determine the expiry boundary
+        if keep_last_n is not None:
+            if keep_last_n < 1:
+                msg = "keep_last_n must be >= 1"
+                raise ValueError(msg)
+            rows = con.execute(
+                "SELECT snapshot_id FROM ducklake_snapshot "
+                "ORDER BY snapshot_id DESC"
+            ).fetchall()
+            all_ids = [r[0] for r in rows]
+            if len(all_ids) <= keep_last_n:
+                return 0
+            # Expire everything before the Nth-from-last
+            older_than_snapshot = all_ids[keep_last_n - 1]
+
+        assert older_than_snapshot is not None
+
+        # Find snapshots to expire
+        expire_rows = con.execute(
+            "SELECT snapshot_id FROM ducklake_snapshot "
+            "WHERE snapshot_id < ?",
+            [older_than_snapshot],
+        ).fetchall()
+        expire_ids = [r[0] for r in expire_rows]
+
+        if not expire_ids:
+            return 0
+
+        # Clean up metadata for files that ended within the expired range.
+        # Files with end_snapshot <= older_than_snapshot are no longer
+        # reachable by any remaining snapshot.
+        boundary = older_than_snapshot
+
+        # Delete file column stats for expired data files
+        con.execute(
+            "DELETE FROM ducklake_file_column_stats "
+            "WHERE data_file_id IN ("
+            "  SELECT data_file_id FROM ducklake_data_file "
+            "  WHERE end_snapshot IS NOT NULL AND end_snapshot <= ?"
+            ")",
+            [boundary],
+        )
+
+        # Delete partition values for expired data files
+        try:
+            con.execute(
+                "DELETE FROM ducklake_file_partition_value "
+                "WHERE data_file_id IN ("
+                "  SELECT data_file_id FROM ducklake_data_file "
+                "  WHERE end_snapshot IS NOT NULL AND end_snapshot <= ?"
+                ")",
+                [boundary],
+            )
+        except Exception:
+            pass  # table may not exist
+
+        # Delete expired data files
+        con.execute(
+            "DELETE FROM ducklake_data_file "
+            "WHERE end_snapshot IS NOT NULL AND end_snapshot <= ?",
+            [boundary],
+        )
+
+        # Delete expired delete files
+        con.execute(
+            "DELETE FROM ducklake_delete_file "
+            "WHERE end_snapshot IS NOT NULL AND end_snapshot <= ?",
+            [boundary],
+        )
+
+        # Delete snapshot_changes for expired snapshots
+        for sid in expire_ids:
+            con.execute(
+                "DELETE FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+                [sid],
+            )
+
+        # Delete the snapshot rows themselves
+        for sid in expire_ids:
+            con.execute(
+                "DELETE FROM ducklake_snapshot WHERE snapshot_id = ?",
+                [sid],
+            )
+
+        con.commit()
+        return len(expire_ids)
+
+    # ------------------------------------------------------------------
+    # VACUUM — delete orphaned Parquet files
+    # ------------------------------------------------------------------
+
+    def vacuum(self) -> int:
+        """Delete orphaned Parquet files not referenced by any catalog entry.
+
+        Scans all data and delete file paths stored in the catalog
+        (including files that haven't been expired yet), then walks the
+        data directory and removes any ``.parquet`` files that are not
+        in the catalog.
+
+        Returns the number of files deleted.
+        """
+        con = self._connect()
+
+        # Collect all referenced file paths (relative to data_path)
+        # from both data files and delete files
+        referenced: set[str] = set()
+
+        # Get all schema/table paths for resolving relative file paths
+        schemas = con.execute(
+            "SELECT DISTINCT path, path_is_relative FROM ducklake_schema"
+        ).fetchall()
+        tables = con.execute(
+            "SELECT DISTINCT t.path, t.path_is_relative, s.path, s.path_is_relative "
+            "FROM ducklake_table t "
+            "JOIN ducklake_schema s ON t.schema_id = s.schema_id"
+        ).fetchall()
+
+        data_base = self.data_path
+
+        # Build full paths for all data files
+        data_files = con.execute(
+            "SELECT df.path, df.path_is_relative, t.path, t.path_is_relative, "
+            "s.path, s.path_is_relative "
+            "FROM ducklake_data_file df "
+            "JOIN ducklake_table t ON df.table_id = t.table_id "
+            "JOIN ducklake_schema s ON t.schema_id = s.schema_id"
+        ).fetchall()
+        for f_path, f_rel, t_path, t_rel, s_path, s_rel in data_files:
+            abs_path = self._resolve_vacuum_path(
+                f_path, bool(f_rel) if f_rel is not None else True,
+                t_path or "", bool(t_rel) if t_rel is not None else True,
+                s_path or "", bool(s_rel) if s_rel is not None else True,
+                data_base,
+            )
+            referenced.add(os.path.normpath(abs_path))
+
+        # Build full paths for all delete files
+        delete_files = con.execute(
+            "SELECT df.path, df.path_is_relative, t.path, t.path_is_relative, "
+            "s.path, s.path_is_relative "
+            "FROM ducklake_delete_file df "
+            "JOIN ducklake_table t ON df.table_id = t.table_id "
+            "JOIN ducklake_schema s ON t.schema_id = s.schema_id"
+        ).fetchall()
+        for f_path, f_rel, t_path, t_rel, s_path, s_rel in delete_files:
+            abs_path = self._resolve_vacuum_path(
+                f_path, bool(f_rel) if f_rel is not None else True,
+                t_path or "", bool(t_rel) if t_rel is not None else True,
+                s_path or "", bool(s_rel) if s_rel is not None else True,
+                data_base,
+            )
+            referenced.add(os.path.normpath(abs_path))
+
+        # Walk the data directory and find all .parquet files
+        deleted_count = 0
+        for dirpath, _dirnames, filenames in os.walk(data_base):
+            for fname in filenames:
+                if fname.endswith(".parquet"):
+                    full_path = os.path.normpath(os.path.join(dirpath, fname))
+                    if full_path not in referenced:
+                        os.remove(full_path)
+                        deleted_count += 1
+
+        return deleted_count
+
+    @staticmethod
+    def _resolve_vacuum_path(
+        file_path: str,
+        file_is_relative: bool,
+        table_path: str,
+        table_path_rel: bool,
+        schema_path: str,
+        schema_path_rel: bool,
+        data_base: str,
+    ) -> str:
+        """Resolve a file path for vacuum operations."""
+        if not file_is_relative:
+            return file_path
+        base = data_base
+        if schema_path_rel:
+            base = os.path.join(base, schema_path)
+        else:
+            base = schema_path
+        if table_path_rel:
+            base = os.path.join(base, table_path)
+        else:
+            base = table_path
+        return os.path.join(base, file_path)

--- a/tests/test_write_maintenance.py
+++ b/tests/test_write_maintenance.py
@@ -1,0 +1,447 @@
+"""Tests for catalog maintenance: expire_snapshots, vacuum, author/commit_message."""
+
+from __future__ import annotations
+
+import os
+
+import polars as pl
+import pytest
+
+from ducklake_polars import (
+    delete_ducklake,
+    expire_snapshots,
+    merge_ducklake,
+    read_ducklake,
+    update_ducklake,
+    vacuum_ducklake,
+    write_ducklake,
+)
+
+
+# ---------------------------------------------------------------------------
+# author / commit_message on write operations
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorCommitMessage:
+    """Verify author and commit_message are stored in snapshot_changes."""
+
+    def test_write_with_author_and_message(self, make_write_catalog):
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1, 2, 3]})
+
+        write_ducklake(
+            df, cat.metadata_path, "test", mode="error",
+            author="alice", commit_message="initial load",
+        )
+
+        row = cat.query_one(
+            "SELECT author, commit_message FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row[0] == "alice"
+        assert row[1] == "initial load"
+
+    def test_write_without_author(self, make_write_catalog):
+        """When author/commit_message are not set, NULLs are stored."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1]})
+
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        row = cat.query_one(
+            "SELECT author, commit_message FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row[0] is None
+        assert row[1] is None
+
+    def test_delete_with_author(self, make_write_catalog):
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        delete_ducklake(
+            cat.metadata_path, "test", pl.col("a") == 1,
+            author="bob", commit_message="remove row 1",
+        )
+
+        row = cat.query_one(
+            "SELECT author, commit_message FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row[0] == "bob"
+        assert row[1] == "remove row 1"
+
+    def test_update_with_author(self, make_write_catalog):
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        update_ducklake(
+            cat.metadata_path, "test",
+            {"b": "z"}, pl.col("a") == 1,
+            author="charlie", commit_message="fix row",
+        )
+
+        row = cat.query_one(
+            "SELECT author, commit_message FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row[0] == "charlie"
+        assert row[1] == "fix row"
+
+    def test_merge_with_author(self, make_write_catalog):
+        cat = make_write_catalog()
+        df = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+        write_ducklake(df, cat.metadata_path, "test", mode="error")
+
+        source = pl.DataFrame({"id": [2, 3], "val": ["B", "c"]})
+        merge_ducklake(
+            cat.metadata_path, "test", source, "id",
+            when_matched_update=True,
+            author="dana", commit_message="merge update",
+        )
+
+        row = cat.query_one(
+            "SELECT author, commit_message FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row[0] == "dana"
+        assert row[1] == "merge update"
+
+    def test_append_with_author(self, make_write_catalog):
+        """Append mode also records author."""
+        cat = make_write_catalog()
+        df1 = pl.DataFrame({"a": [1]})
+        write_ducklake(df1, cat.metadata_path, "test", mode="error")
+
+        df2 = pl.DataFrame({"a": [2]})
+        write_ducklake(
+            df2, cat.metadata_path, "test", mode="append",
+            author="eve", commit_message="add row",
+        )
+
+        row = cat.query_one(
+            "SELECT author, commit_message FROM ducklake_snapshot_changes "
+            "ORDER BY snapshot_id DESC LIMIT 1"
+        )
+        assert row[0] == "eve"
+        assert row[1] == "add row"
+
+
+# ---------------------------------------------------------------------------
+# expire_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestExpireSnapshots:
+    """Test expire_snapshots functionality."""
+
+    def test_expire_older_than_snapshot(self, make_write_catalog):
+        """Expire snapshots older than a given ID."""
+        cat = make_write_catalog()
+
+        # Create multiple snapshots
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [2]}), cat.metadata_path, "test", mode="append",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [3]}), cat.metadata_path, "test", mode="append",
+        )
+
+        # Count snapshots before expiry
+        snap_count_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+        assert snap_count_before >= 4  # initial + 3 writes
+
+        # Get the latest snapshot ID
+        latest = cat.query_one(
+            "SELECT MAX(snapshot_id) FROM ducklake_snapshot"
+        )[0]
+
+        # Expire all but the last 2 snapshots by ID
+        expired = expire_snapshots(
+            cat.metadata_path, older_than_snapshot=latest - 1,
+        )
+        assert expired > 0
+
+        # Remaining snapshots should be fewer
+        snap_count_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+        assert snap_count_after == snap_count_before - expired
+
+        # Data should still be readable at latest snapshot
+        result = read_ducklake(cat.metadata_path, "test")
+        assert sorted(result["a"].to_list()) == [1, 2, 3]
+
+    def test_expire_keep_last_n(self, make_write_catalog):
+        """keep_last_n preserves the N most recent snapshots."""
+        cat = make_write_catalog()
+
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [2]}), cat.metadata_path, "test", mode="append",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [3]}), cat.metadata_path, "test", mode="append",
+        )
+
+        snap_count_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+
+        expired = expire_snapshots(cat.metadata_path, keep_last_n=2)
+        assert expired == snap_count_before - 2
+
+        snap_count_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+        assert snap_count_after == 2
+
+        # Data still readable
+        result = read_ducklake(cat.metadata_path, "test")
+        assert sorted(result["a"].to_list()) == [1, 2, 3]
+
+    def test_expire_nothing_when_all_recent(self, make_write_catalog):
+        """No expiry when all snapshots are recent enough."""
+        cat = make_write_catalog()
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+
+        snap_count = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot"
+        )[0]
+
+        expired = expire_snapshots(cat.metadata_path, keep_last_n=snap_count + 5)
+        assert expired == 0
+
+    def test_expire_cleans_up_snapshot_changes(self, make_write_catalog):
+        """Expired snapshot's changes records are also removed."""
+        cat = make_write_catalog()
+
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [2]}), cat.metadata_path, "test", mode="append",
+        )
+
+        changes_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot_changes"
+        )[0]
+
+        expired = expire_snapshots(cat.metadata_path, keep_last_n=1)
+        assert expired > 0
+
+        changes_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_snapshot_changes"
+        )[0]
+        assert changes_after < changes_before
+
+    def test_expire_cleans_up_ended_data_files(self, make_write_catalog):
+        """Expired data file metadata is removed after overwrite + expire."""
+        cat = make_write_catalog()
+
+        # Write, then overwrite — first file gets end_snapshot set
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [99]}), cat.metadata_path, "test", mode="overwrite",
+        )
+
+        files_before = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_data_file"
+        )[0]
+
+        expire_snapshots(cat.metadata_path, keep_last_n=1)
+
+        files_after = cat.query_one(
+            "SELECT COUNT(*) FROM ducklake_data_file"
+        )[0]
+        # The overwritten file's metadata should be cleaned up
+        assert files_after < files_before
+
+        # Data still readable
+        result = read_ducklake(cat.metadata_path, "test")
+        assert result["a"].to_list() == [99]
+
+    def test_expire_both_params_raises(self, make_write_catalog):
+        cat = make_write_catalog()
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            expire_snapshots(
+                cat.metadata_path, older_than_snapshot=1, keep_last_n=1,
+            )
+
+    def test_expire_no_params_raises(self, make_write_catalog):
+        cat = make_write_catalog()
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        with pytest.raises(ValueError, match="Must specify either"):
+            expire_snapshots(cat.metadata_path)
+
+    def test_expire_keep_last_n_zero_raises(self, make_write_catalog):
+        cat = make_write_catalog()
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        with pytest.raises(ValueError, match="keep_last_n must be >= 1"):
+            expire_snapshots(cat.metadata_path, keep_last_n=0)
+
+
+# ---------------------------------------------------------------------------
+# vacuum_ducklake
+# ---------------------------------------------------------------------------
+
+
+class TestVacuum:
+    """Test vacuum_ducklake functionality."""
+
+    def test_vacuum_removes_orphaned_files(self, make_write_catalog):
+        """After overwrite + expire, vacuum deletes the orphaned file."""
+        cat = make_write_catalog()
+
+        write_ducklake(
+            pl.DataFrame({"a": [1]}), cat.metadata_path, "test", mode="error",
+        )
+        write_ducklake(
+            pl.DataFrame({"a": [99]}), cat.metadata_path, "test", mode="overwrite",
+        )
+
+        # Count parquet files before
+        parquet_before = _count_parquet_files(cat.data_path)
+        assert parquet_before >= 2  # at least original + overwrite
+
+        # Expire old snapshots to make old file unreferenced in metadata
+        expire_snapshots(cat.metadata_path, keep_last_n=1)
+
+        # Vacuum
+        deleted = vacuum_ducklake(cat.metadata_path)
+        assert deleted >= 1
+
+        # Remaining parquet files should be fewer
+        parquet_after = _count_parquet_files(cat.data_path)
+        assert parquet_after < parquet_before
+
+        # Data still readable
+        result = read_ducklake(cat.metadata_path, "test")
+        assert result["a"].to_list() == [99]
+
+    def test_vacuum_preserves_referenced_files(self, make_write_catalog):
+        """Vacuum does not delete files that are still referenced."""
+        cat = make_write_catalog()
+
+        write_ducklake(
+            pl.DataFrame({"a": [1, 2]}), cat.metadata_path, "test", mode="error",
+        )
+
+        parquet_before = _count_parquet_files(cat.data_path)
+
+        deleted = vacuum_ducklake(cat.metadata_path)
+        assert deleted == 0
+
+        parquet_after = _count_parquet_files(cat.data_path)
+        assert parquet_after == parquet_before
+
+    def test_vacuum_empty_data_dir(self, make_write_catalog):
+        """Vacuum on an empty catalog returns 0."""
+        cat = make_write_catalog()
+
+        deleted = vacuum_ducklake(cat.metadata_path)
+        assert deleted == 0
+
+    def test_vacuum_after_delete_and_expire(self, make_write_catalog):
+        """Delete files are also cleaned up by vacuum after expire."""
+        cat = make_write_catalog()
+
+        write_ducklake(
+            pl.DataFrame({"a": [1, 2, 3]}), cat.metadata_path, "test", mode="error",
+        )
+
+        # Delete a row — creates a delete file
+        delete_ducklake(cat.metadata_path, "test", pl.col("a") == 2)
+
+        parquet_before = _count_parquet_files(cat.data_path)
+        assert parquet_before >= 2  # data file + delete file
+
+        # Overwrite to make delete file obsolete
+        write_ducklake(
+            pl.DataFrame({"a": [1, 3]}), cat.metadata_path, "test", mode="overwrite",
+        )
+
+        # Expire + vacuum
+        expire_snapshots(cat.metadata_path, keep_last_n=1)
+        deleted = vacuum_ducklake(cat.metadata_path)
+        assert deleted >= 1
+
+        # Data still readable
+        result = read_ducklake(cat.metadata_path, "test")
+        assert sorted(result["a"].to_list()) == [1, 3]
+
+    def test_expire_then_vacuum_full_workflow(self, make_write_catalog):
+        """End-to-end: create, insert, overwrite, expire, vacuum."""
+        cat = make_write_catalog()
+
+        # Create table with initial data
+        write_ducklake(
+            pl.DataFrame({"x": [10, 20]}), cat.metadata_path, "tbl", mode="error",
+        )
+
+        # Append more data
+        write_ducklake(
+            pl.DataFrame({"x": [30]}), cat.metadata_path, "tbl", mode="append",
+        )
+
+        # Overwrite with fresh data
+        write_ducklake(
+            pl.DataFrame({"x": [100, 200]}), cat.metadata_path, "tbl", mode="overwrite",
+        )
+
+        # At this point we have old parquet files from create/append that
+        # are superseded by the overwrite
+        parquet_count = _count_parquet_files(cat.data_path)
+        assert parquet_count >= 2
+
+        # Expire all but the latest snapshot
+        expired = expire_snapshots(cat.metadata_path, keep_last_n=1)
+        assert expired > 0
+
+        # Vacuum orphans
+        vacuumed = vacuum_ducklake(cat.metadata_path)
+        assert vacuumed >= 1
+
+        # Verify final data
+        result = read_ducklake(cat.metadata_path, "tbl")
+        assert sorted(result["x"].to_list()) == [100, 200]
+
+        # Only active files remain
+        parquet_final = _count_parquet_files(cat.data_path)
+        assert parquet_final == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_parquet_files(data_path: str) -> int:
+    """Count all .parquet files under a directory."""
+    count = 0
+    for dirpath, _dirs, files in os.walk(data_path):
+        for f in files:
+            if f.endswith(".parquet"):
+                count += 1
+    return count


### PR DESCRIPTION
## PR 7: Catalog Maintenance

### New API
- `expire_snapshots(path, older_than_snapshot=None, keep_last_n=None)`
- `vacuum_ducklake(path)` — delete orphaned Parquet/delete files
- All write ops now accept optional `author` and `commit_message` params

### Tests
- 19 new tests in `tests/test_write_maintenance.py`
- 571 total, all passing