### PR TITLE
feat: field_id-based column mapping for schema evolution

### DIFF
--- a/TEST_PARITY.md
+++ b/TEST_PARITY.md
@@ -1,0 +1,182 @@
+# DuckLake DataFrame ↔ DuckDB Reference Test Parity Report
+
+Generated: 2026-03-03
+
+## Summary
+
+| Metric | ducklake-ref (DuckDB) | ducklake-dataframe (Polars `tests/`) |
+|---|---|---|
+| Test files / modules | 345 `.test` files across 48 categories | 31 `.py` modules, ~895 test functions |
+| Test categories | 48 directories | ~20 logical areas |
+
+The ducklake-dataframe test suite is **extensive for the features it supports** (basic CRUD, schema evolution, partitioning, inlining, views, maintenance, merge, interop, stats/filters, types, time travel, concurrency, tags). However, there are significant **categories in ducklake-ref that have zero or minimal coverage** in ducklake-dataframe.
+
+---
+
+## Coverage Matrix
+
+### ✅ Well-Covered (ducklake-dataframe has solid tests)
+
+| ducklake-ref category | ref tests | DF coverage | Notes |
+|---|---|---|---|
+| **delete** | 11 | ✅ `test_delete.py` + `test_write_delete.py` (40+ tests) | Basic, multi-file, time travel, truncate, sequential, rollback |
+| **update** | 7 | ✅ `test_update.py` + `test_write_update.py` (30+ tests) | Single/multi column, expressions, spanning files, time travel |
+| **alter** | 25 | ✅ `test_write_alter.py` + `test_schema_evolution.py` (60+ tests) | Add/drop/rename column, type promotion, struct evolution, sort keys |
+| **types** | 11 | ✅ `test_types.py` (50+ tests) | All integer/float/temporal/compound types, NaN, infinity, null bytes, variant |
+| **data_inlining** | 31 | ✅ `test_inlined.py` + `test_write_inline.py` (40+ tests) | Basic, types, filter, delete, update, flush, threshold, time travel |
+| **partitioning** | 10 | ✅ `test_partition.py` + `test_write_partition.py` (40+ tests) | Single/multi key, filter, year/month, delete, update, interop |
+| **time_travel** | 2 | ✅ `test_time_travel.py` (15+ tests) | Version, timestamp, schema, struct/list, dropped tables |
+| **view** | 8 | ✅ `test_write_views.py` (20+ tests) | Create, drop, replace, schema, interop, metadata |
+| **merge** | 5 | ✅ `test_write_merge.py` (20+ tests) | Upsert, insert-only, update-only, composite key, interop |
+| **table_changes** | 8 | ✅ `test_catalog_api.py` (insertions/deletions/changes tests) | Insertions, deletions, mixed changes, multi-snapshot ranges |
+| **stats** | 11 | ✅ `test_stats_filter.py` (20+ tests) | Integer/date/varchar/decimal filter pushdown, sort+limit, null filters |
+| **concurrent** | 4 | ✅ `test_concurrent.py` (5 tests) | Concurrent inserts, retry, conflict detection |
+| **catalog** | 4 | ✅ `test_catalog_general.py` + `test_catalog_api.py` | Schemas, tables, drop/recreate, quoted identifiers |
+| **functions** | 2 | ✅ `test_catalog_api.py` | `snapshots()`, `table_info()` covered via catalog API |
+| **schema_evolution** | 1 | ✅ `test_schema_evolution.py` + `test_field_id.py` | Field IDs, renames, struct evolution |
+| **insert** | 3 | ✅ `test_write.py` + `test_basic.py` | Insert modes, interop, multiple inserts, CTAS |
+
+### ⚠️ Partially Covered
+
+| ducklake-ref category | ref tests | DF coverage | Gaps |
+|---|---|---|---|
+| **compaction** | 27 | ⚠️ `test_write_maintenance.py` has expire_snapshots + vacuum | **No merge-adjacent / merge-rewrite tests**. Missing: compaction after alter table, compaction with partitioned tables, compaction size limits, multi-compaction, cleanup-after-compaction. ducklake-ref has 27 tests; DF has ~7 maintenance tests covering only expire + vacuum. |
+| **deletion_inlining** | 15 | ⚠️ Partial via `test_write_inline.py` delete tests | DF tests inline deletion from polars side, but ducklake-ref has dedicated tests for: deletion inlining with alter, compaction, concurrency, encryption, large data, partitions, stats, transaction semantics. These edge cases are missing. |
+| **sorted_table** | 26 | ⚠️ `test_write_alter.py` has ~10 sort-key tests | DF covers `set_sort_keys` / `reset_sort_keys` + basic validation. Missing: **sorted merge-adjacent** (the main use case — 13 tests in ref), flush-sorted inlining, sorted expressions, macro-based sort expressions, spatial hilbert sort. |
+| **comments** | 5 | ⚠️ `test_tags.py` covers tags (comments) | DF maps DuckDB COMMENT → tags. But missing: comment on column directly, comment mixed with other operations in same transaction, comment schema versioning. |
+| **general** | 13 | ⚠️ Partial | Missing: database_size, attach_at_snapshot, read_only mode, generated_columns (error), metadata_cache, prepared_statement, missing_parquet error handling, recursive_metadata_catalog. Only `data_path` and `paths` partially covered. |
+| **default** | 4 | ⚠️ `test_schema_evolution.py` has add_column_with_default | Missing: default_values on CREATE TABLE, default_expressions (complex defaults), struct_field_default. |
+| **transaction** | 12 | ⚠️ `test_concurrent.py` covers conflicts | Missing: transaction rollback semantics, transaction-local visibility, create conflicts, schema transactions, insert+update+delete in single transaction, conflict cleanup, inlining within transactions. |
+| **constraints** | 3 | ⚠️ Minimal | NOT NULL is tested implicitly but no dedicated constraint tests. Missing: NOT NULL on create, NOT NULL with drop column, unsupported constraint error handling. |
+
+### ❌ Not Covered (zero tests in ducklake-dataframe)
+
+| ducklake-ref category | ref tests | What it tests | Priority |
+|---|---|---|---|
+| **add_files** | 31 | Adding external Parquet files to DuckLake (hive, nested, type checking, rollback, rename, compaction) | 🟡 Medium — Important for interop with external file ingestion workflows |
+| **rewrite_data_files** | 10 | Rewriting data files after deletes to reclaim space (threshold, concurrency, partitioning, merge-adjacent, row ID preservation) | 🟡 Medium — Important for storage optimization |
+| **encryption** | 2 | Encrypted parquet files (ENCRYPTED option), partitioning + encryption | 🟡 Medium — Security feature |
+| **macros** | 10 | DuckLake-persisted scalar/table macros, macro transactions, time travel, multiple implementations, defined types | 🔴 High — Macros are a catalog feature; if DF exposes catalog, these should be tested |
+| **rowid** | 2 | Virtual row ID tracking, row ID stability after updates | 🟡 Medium — Internal but useful for MERGE correctness |
+| **virtualcolumns** | 2 | `file_row_number`, `snapshot_id` virtual columns | 🟡 Medium — Useful for auditing |
+| **snapshot_info** | 2 | `ducklake_current_commit()`, `ducklake_last_commit()` functions | 🟢 Low — DuckDB-specific functions |
+| **audit** | 1 | Author/commit message tracking on snapshots | ✅ Covered by `test_write_maintenance.py` author tests — **miscategorized here, actually covered** |
+| **attach** | 2 | ATTACH REPLACE, different data paths | 🟢 Low — DuckDB SQL-specific |
+| **autoloading** | 1 | Auto-loading data path from extension | 🟢 Low — DuckDB-specific |
+| **checkpoint** | 4 | Checkpointing behavior, interleaved updates, views | 🟢 Low — DuckDB-internal |
+| **cleanup** | 2 | Cleanup old files, create-drop cleanup | 🟡 Medium — Overlaps with vacuum but distinct |
+| **cloud** | 1 | Cloud storage test cases (S3/MinIO) | 🟡 Medium — Cloud support |
+| **geo** | 5 | GEOMETRY type support, spatial add_files, inlining, merge, nested | 🟡 Medium — Spatial extension feature |
+| **initialize** | 2 | Creating new DuckLake, read_only mode initialization | 🟢 Low — DuckDB-specific |
+| **issues** | 1 | Late materialization bug regression | 🟢 Low — Regression test |
+| **list_files** | 1 | `ducklake_list_files()` function | ✅ Covered via `test_catalog_api.py` list_files tests |
+| **metadata** | 5 | DuckDB tables metadata, settings for different backends (Postgres, SQLite, MinIO) | 🟢 Low — DuckDB metadata queries |
+| **migration** | 4 | Schema migration from older DuckLake versions | 🟡 Medium — Version compatibility |
+| **remove_orphans** | 2 | Remove orphaned files (mixed paths) | ✅ Covered by `test_write_maintenance.py` vacuum tests |
+| **secrets** | 1 | DuckLake secrets/connection management | 🟢 Low — DuckDB-specific |
+| **settings** | 5 | Parquet compression, row group size, per-table settings, per-thread output, max retry | 🟡 Medium — Configuration |
+
+---
+
+## Top Priority Gaps
+
+### 1. **Compaction / Merge-Adjacent** (27 ref tests → ~0 DF tests)
+The biggest gap. ducklake-ref has extensive tests for:
+- Merging adjacent small files into larger ones
+- Compaction with partitioned tables
+- Compaction after ALTER TABLE
+- Compaction size limits and max file counts
+- Multi-table compaction
+- Cleanup after compaction
+
+**Recommendation:** Add `test_write_compaction.py` with merge-adjacent tests.
+
+### 2. **Sorted Table / Sorted Merge** (26 ref tests → ~10 DF tests)
+DF covers setting sort keys but not the **actual sorted merge behavior**:
+- Merge-adjacent respecting sort order
+- Sorted flush from inlined data
+- Sort expressions (not just column names)
+- Macro-based sort expressions
+- Reset/rollback of sort configuration
+
+**Recommendation:** Expand `test_write_alter.py` sort tests or add `test_sorted_table.py`.
+
+### 3. **Deletion Inlining Edge Cases** (15 ref tests → ~3 DF tests)
+DF tests basic inline deletion but misses:
+- Deletion from inlined data across multiple snapshots
+- Deletion inlining with concurrent operations
+- Deletion inlining interaction with ALTER TABLE
+- Deletion inlining with partitions
+- Stats correctness after deletion inlining
+
+**Recommendation:** Add dedicated deletion-inlining section to `test_write_inline.py`.
+
+### 4. **Rewrite Data Files** (10 ref tests → 0 DF tests)
+No DF tests for rewriting data files to remove deleted rows:
+- Rewrite after repeated insert+delete cycles
+- Rewrite threshold parameters
+- Rewrite with concurrency
+- Rewrite with partitioning
+- Row ID preservation after rewrite
+
+**Recommendation:** Add `test_write_rewrite.py` if the feature is supported.
+
+### 5. **Transaction Semantics** (12 ref tests → ~5 DF tests)
+DF tests concurrent inserts but misses:
+- Transaction-local visibility (read your own writes before commit)
+- Rollback semantics
+- Multi-operation transactions (insert + update + delete)
+- Create table conflict detection
+- Schema-level transactions
+
+**Recommendation:** Add `test_transactions.py` with proper transaction isolation tests.
+
+### 6. **Macros** (10 ref tests → 0 DF tests)
+If DuckLake catalog supports macros, this is a significant gap:
+- Scalar and table macros persisted in catalog
+- Macro transactions and time travel
+- Multiple macro implementations
+- Defined types
+
+**Recommendation:** Add `test_macros.py` if macros are supported via the DataFrame API.
+
+### 7. **Add Files (External File Ingestion)** (31 ref tests → 0 DF tests)
+Adding external Parquet files is a core DuckLake feature:
+- Adding files with schema validation
+- Type checking (integer, float, decimal, timestamp, UUID)
+- Hive-partitioned file addition
+- Handling extra/missing columns
+
+**Recommendation:** Add `test_add_files.py` if the feature is exposed.
+
+---
+
+## Features Intentionally Out of Scope
+
+These ducklake-ref categories are **DuckDB SQL-specific** and don't need DataFrame API coverage:
+
+- `attach` / `autoloading` / `initialize` — DuckDB ATTACH semantics
+- `checkpoint` — DuckDB internal checkpointing
+- `secrets` — DuckDB secret management
+- `metadata` — DuckDB system table queries
+- `migration` — Schema version migration (DuckDB handles this)
+- `issues` / `clickbench` / `tpch` — Regression/benchmark tests
+
+---
+
+## Existing DF-Only Tests (not in ducklake-ref)
+
+ducklake-dataframe has tests with **no direct ducklake-ref equivalent**:
+
+| DF test module | What it covers |
+|---|---|
+| `test_backend.py` | Backend detection (SQLite vs PostgreSQL), URI parsing |
+| `test_schema_mapping.py` | DuckDB type string → Polars type mapping |
+| `test_field_id.py` | Parquet field ID tracking after renames (50+ tests) |
+| `test_property.py` | Property-based / fuzz-style tests (Hypothesis-like) |
+| `test_edge_cases.py` | Exhaustive edge cases (100+ tests): wide tables, special chars, Unicode, boundaries |
+| `test_interop.py` | Bidirectional DuckDB ↔ Polars interop (150+ tests) |
+| `test_tags.py` | Tag/property system (maps to DuckDB COMMENT) |
+| `test_duckdb_backend.py` | DuckDB-specific backend API tests |
+
+These are **strengths** of the DF test suite — the interop and edge case coverage goes well beyond what ducklake-ref tests.

--- a/benchmarks/profile_read.py
+++ b/benchmarks/profile_read.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Profile the DuckLake read path to find bottlenecks."""
+
+import os
+import shutil
+import tempfile
+import time
+
+import duckdb
+import numpy as np
+import polars as pl
+
+CATEGORIES = ["electronics", "books", "clothing", "food", "toys", "sports"]
+
+
+def generate_df(n):
+    rng = np.random.default_rng(42)
+    return pl.DataFrame({
+        "id": list(range(n)),
+        "name": [f"item_{i}" for i in range(n)],
+        "value": rng.uniform(0, 1000, n).tolist(),
+        "category": [CATEGORIES[i % len(CATEGORIES)] for i in range(n)],
+        "ts": [f"2024-01-01T{(i % 24):02d}:{(i % 60):02d}:00+00:00" for i in range(n)],
+    }).with_columns(pl.col("ts").str.to_datetime("%Y-%m-%dT%H:%M:%S%z"))
+
+
+def setup_catalog(base_dir):
+    meta = os.path.join(base_dir, "profile.ducklake")
+    data = os.path.join(base_dir, "profile_data")
+    os.makedirs(data, exist_ok=True)
+    attach = f"ducklake:sqlite:{meta}"
+    con = duckdb.connect()
+    con.install_extension("ducklake")
+    con.load_extension("ducklake")
+    con.execute(f"ATTACH '{attach}' AS ducklake (DATA_PATH '{data}', DATA_INLINING_ROW_LIMIT 0)")
+    return meta, data, con
+
+
+def profile_read(n=10000):
+    tmp = tempfile.mkdtemp()
+    try:
+        meta, data, con = setup_catalog(tmp)
+        df = generate_df(n)
+        con.execute(
+            "CREATE TABLE ducklake.bench "
+            "(id INTEGER, name VARCHAR, value DOUBLE, category VARCHAR, ts TIMESTAMP WITH TIME ZONE)"
+        )
+        con.execute("INSERT INTO ducklake.bench SELECT * FROM df")
+        con.close()
+
+        # Profile individual catalog operations
+        from ducklake_polars._catalog import DuckLakeCatalogReader
+
+        times = {}
+
+        # Full read path
+        reader = DuckLakeCatalogReader(meta, data_path_override=data)
+        reader._connect()
+
+        t0 = time.perf_counter()
+        snapshot = reader.get_current_snapshot()
+        times["get_current_snapshot"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        table = reader.get_table("bench", "main", snapshot.snapshot_id)
+        times["get_table"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        all_columns = reader.get_all_columns(table.table_id, snapshot.snapshot_id)
+        times["get_all_columns"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        columns = [c for c in all_columns if c.parent_column is None]
+        column_names = [c.column_name for c in columns]
+        times["filter_columns"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        data_files = reader.get_data_files(table.table_id, snapshot.snapshot_id)
+        times["get_data_files"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        delete_files = reader.get_delete_files(table.table_id, snapshot.snapshot_id)
+        times["get_delete_files"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        history = reader.get_column_history(table.table_id)
+        times["get_column_history"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        inlined = reader.read_inlined_data(table.table_id, snapshot.snapshot_id, column_names)
+        times["read_inlined_data"] = time.perf_counter() - t0
+
+        # Stats (filter pushdown path)
+        filter_columns = ["id", "value"]
+        t0 = time.perf_counter()
+        file_ids = [f.data_file_id for f in data_files]
+        col_ids = [c.column_id for c in columns if c.column_name in filter_columns]
+        stats = reader.get_column_stats(table.table_id, file_ids, col_ids)
+        times["get_column_stats"] = time.perf_counter() - t0
+
+        # Resolve file paths
+        t0 = time.perf_counter()
+        sources = [reader.resolve_data_file_path(f.path, f.path_is_relative, table) for f in data_files]
+        times["resolve_paths"] = time.perf_counter() - t0
+
+        # Build stats table
+        from ducklake_polars._stats import build_table_statistics
+        t0 = time.perf_counter()
+        table_stats = build_table_statistics(data_files, stats, columns, filter_columns)
+        times["build_table_statistics"] = time.perf_counter() - t0
+
+        # Actual scan_parquet
+        from polars.io.parquet.functions import scan_parquet
+        t0 = time.perf_counter()
+        lf = scan_parquet(sources, missing_columns="insert", extra_columns="ignore",
+                         cast_options=pl.ScanCastOptions(integer_cast="upcast", float_cast="upcast",
+                                                         missing_struct_fields="insert", extra_struct_fields="ignore",
+                                                         categorical_to_string="allow"))
+        result = lf.collect()
+        times["scan_parquet+collect"] = time.perf_counter() - t0
+
+        reader.close()
+
+        # Full end-to-end
+        from ducklake_polars import read_ducklake
+        t0 = time.perf_counter()
+        read_ducklake(meta, "bench")
+        times["full_read_ducklake"] = time.perf_counter() - t0
+
+        total_catalog = sum(v for k, v in times.items()
+                           if k not in ("scan_parquet+collect", "full_read_ducklake", "build_table_statistics", "resolve_paths", "filter_columns"))
+        times["total_catalog_queries"] = total_catalog
+
+        print(f"\nProfile for {n} rows ({len(data_files)} data files):")
+        print("=" * 60)
+        for name, t in sorted(times.items(), key=lambda x: -x[1]):
+            print(f"  {name:30s}: {t*1000:8.2f} ms")
+        print(f"\n  Catalog queries as % of full read: {total_catalog / times['full_read_ducklake'] * 100:.1f}%")
+
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    for n in [1000, 10000, 100000]:
+        profile_read(n)

--- a/benchmarks/profile_read2.py
+++ b/benchmarks/profile_read2.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Detailed profile of the read path including connection overhead and multi-file scenarios."""
+
+import cProfile
+import os
+import pstats
+import shutil
+import tempfile
+import time
+
+import duckdb
+import numpy as np
+import polars as pl
+
+CATEGORIES = ["electronics", "books", "clothing", "food", "toys", "sports"]
+
+
+def generate_df(n):
+    rng = np.random.default_rng(42)
+    return pl.DataFrame({
+        "id": list(range(n)),
+        "name": [f"item_{i}" for i in range(n)],
+        "value": rng.uniform(0, 1000, n).tolist(),
+        "category": [CATEGORIES[i % len(CATEGORIES)] for i in range(n)],
+        "ts": [f"2024-01-01T{(i % 24):02d}:{(i % 60):02d}:00+00:00" for i in range(n)],
+    }).with_columns(pl.col("ts").str.to_datetime("%Y-%m-%dT%H:%M:%S%z"))
+
+
+def setup_catalog_multifile(base_dir, n_rows=10000, n_files=10):
+    """Create catalog with multiple data files."""
+    meta = os.path.join(base_dir, "profile.ducklake")
+    data = os.path.join(base_dir, "profile_data")
+    os.makedirs(data, exist_ok=True)
+    attach = f"ducklake:sqlite:{meta}"
+    con = duckdb.connect()
+    con.install_extension("ducklake")
+    con.load_extension("ducklake")
+    con.execute(f"ATTACH '{attach}' AS ducklake (DATA_PATH '{data}', DATA_INLINING_ROW_LIMIT 0)")
+    con.execute(
+        "CREATE TABLE ducklake.bench "
+        "(id INTEGER, name VARCHAR, value DOUBLE, category VARCHAR, ts TIMESTAMP WITH TIME ZONE)"
+    )
+
+    rows_per_file = n_rows // n_files
+    for i in range(n_files):
+        start = i * rows_per_file
+        end = start + rows_per_file
+        chunk = generate_df(n_rows).slice(start, rows_per_file)
+        con.execute("INSERT INTO ducklake.bench SELECT * FROM chunk")
+
+    con.close()
+    return meta, data
+
+
+def profile_multifile():
+    """Profile read with multiple files."""
+    tmp = tempfile.mkdtemp()
+    try:
+        for n_files in [1, 5, 10, 20]:
+            meta, data = setup_catalog_multifile(tmp + f"_{n_files}", n_rows=10000, n_files=n_files)
+
+            from ducklake_polars import read_ducklake, scan_ducklake
+
+            # Warm up
+            read_ducklake(meta, "bench")
+
+            # Time it
+            times = []
+            for _ in range(5):
+                t0 = time.perf_counter()
+                read_ducklake(meta, "bench")
+                times.append(time.perf_counter() - t0)
+            times.sort()
+            median = times[len(times) // 2]
+
+            # Time with scan (lazy)
+            scan_times = []
+            for _ in range(5):
+                t0 = time.perf_counter()
+                scan_ducklake(meta, "bench").collect()
+                scan_times.append(time.perf_counter() - t0)
+            scan_times.sort()
+            scan_median = scan_times[len(scan_times) // 2]
+
+            print(f"  {n_files:3d} files: read={median*1000:.1f}ms  scan+collect={scan_median*1000:.1f}ms")
+
+    finally:
+        for suffix in ["_1", "_5", "_10", "_20"]:
+            shutil.rmtree(tmp + suffix, ignore_errors=True)
+
+
+def profile_cprofile():
+    """Use cProfile to find exact hotspots."""
+    tmp = tempfile.mkdtemp()
+    try:
+        meta, data = setup_catalog_multifile(tmp, n_rows=100000, n_files=10)
+
+        from ducklake_polars import read_ducklake
+
+        # Warm up
+        read_ducklake(meta, "bench")
+
+        # Profile 10 reads
+        pr = cProfile.Profile()
+        pr.enable()
+        for _ in range(10):
+            read_ducklake(meta, "bench")
+        pr.disable()
+
+        print("\n\nTop 30 by cumulative time (10 reads of 100K rows, 10 files):")
+        print("=" * 100)
+        stats = pstats.Stats(pr)
+        stats.sort_stats("cumulative")
+        stats.print_stats(30)
+
+        print("\n\nTop 20 by total (self) time:")
+        print("=" * 100)
+        stats.sort_stats("tottime")
+        stats.print_stats(20)
+
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    print("Multi-file read profile (10K rows):")
+    print("=" * 60)
+    profile_multifile()
+    profile_cprofile()

--- a/src/ducklake_core/_catalog.py
+++ b/src/ducklake_core/_catalog.py
@@ -171,18 +171,19 @@ class DuckLakeCatalogReader:
     def _connect(self) -> Any:
         if self._con is None:
             self._con = self._backend.connect()
-            self._check_version()
+            self._load_metadata()
         return self._con
 
-    def _check_version(self) -> None:
-        """Validate the DuckLake catalog version is supported."""
-        row = self._con.execute(
-            self._sql("SELECT value FROM ducklake_metadata WHERE key = 'version'")
-        ).fetchone()
-        if row is None:
+    def _load_metadata(self) -> None:
+        """Load version and data_path from ducklake_metadata in a single query."""
+        rows = self._con.execute(
+            "SELECT key, value FROM ducklake_metadata WHERE key IN ('version', 'data_path')"
+        ).fetchall()
+        meta = {r[0]: r[1] for r in rows}
+        version = meta.get("version")
+        if version is None:
             msg = "No version found in ducklake_metadata — is this a valid DuckLake catalog?"
             raise ValueError(msg)
-        version = row[0]
         if version not in SUPPORTED_DUCKLAKE_VERSIONS:
             msg = (
                 f"Unsupported DuckLake catalog version '{version}'. "
@@ -190,6 +191,8 @@ class DuckLakeCatalogReader:
             )
             raise ValueError(msg)
         self._catalog_version = version
+        if self._data_path_override is None and "data_path" in meta:
+            self._data_path = meta["data_path"]
 
     def _sql(self, query: str) -> str:
         """Translate ``?`` placeholders to the backend's parameter style.
@@ -496,6 +499,24 @@ class DuckLakeCatalogReader:
             for r in rows
         ]
 
+    def has_column_changes(self, table_id: int) -> bool:
+        """Fast check: has any column ever been dropped, renamed, or re-added?
+
+        Returns True if any column in the table has ``end_snapshot IS NOT NULL``,
+        which is a necessary condition for renames, drops, or type changes to
+        exist.  When this returns False, ``get_column_history`` + ``_has_renames``
+        can be skipped entirely.
+        """
+        con = self._connect()
+        row = con.execute(
+            self._sql(
+                "SELECT EXISTS(SELECT 1 FROM ducklake_column "
+                "WHERE table_id = ? AND end_snapshot IS NOT NULL)"
+            ),
+            [table_id],
+        ).fetchone()
+        return bool(row and row[0])
+
     def get_column_history(self, table_id: int) -> list[ColumnHistoryEntry]:
         """Get all column definitions across all snapshots (for rename detection).
 
@@ -669,6 +690,25 @@ class DuckLakeCatalogReader:
             )
             for r in rows
         ]
+
+    def get_name_mapping(self, mapping_id: int) -> dict[int, str]:
+        """Return ``{target_field_id: source_name}`` for a name mapping.
+
+        Each data file records a ``mapping_id`` that links to the
+        ``ducklake_name_mapping`` table.  The mapping tells us the
+        physical column name in the Parquet file (``source_name``) and
+        the column ID it corresponds to (``target_field_id``).
+        """
+        con = self._connect()
+        rows = con.execute(
+            self._sql(
+                "SELECT source_name, target_field_id "
+                "FROM ducklake_name_mapping "
+                "WHERE mapping_id = ?"
+            ),
+            [mapping_id],
+        ).fetchall()
+        return {int(r[1]): r[0] for r in rows}
 
     def get_all_snapshots(self) -> list[tuple]:
         """Get all snapshots ordered by snapshot_id."""

--- a/src/ducklake_polars/_dataset.py
+++ b/src/ducklake_polars/_dataset.py
@@ -139,6 +139,44 @@ def _top_level_history(history: list[ColumnHistoryEntry]) -> list[ColumnHistoryE
     return [e for e in history if e.parent_column is None]
 
 
+def _has_renames_from_mappings(
+    data_files: list[FileInfo],
+    name_mappings: dict[int, dict[int, str]],
+    current_columns: list[ColumnInfo],
+    resolved_paths: dict[int, str] | None = None,
+) -> bool:
+    """Check if any file's name mapping indicates renames or drop+re-add conflicts.
+
+    When *resolved_paths* is provided (``{data_file_id: abs_path}``), files
+    without a ``mapping_id`` are checked via Parquet field_id metadata.
+    """
+    current_names: dict[int, str] = {c.column_id: c.column_name for c in current_columns if c.parent_column is None}
+    current_name_set = set(current_names.values())
+
+    for f in data_files:
+        mapping: dict[int, str] | None = None
+
+        if f.mapping_id is not None and f.mapping_id in name_mappings:
+            mapping = name_mappings[f.mapping_id]
+        elif resolved_paths and f.data_file_id in resolved_paths:
+            # Read field_ids from Parquet metadata
+            field_ids = _read_field_ids_from_parquet(resolved_paths[f.data_file_id])
+            if field_ids:
+                # Convert {name: fid} → {fid: name}
+                mapping = {fid: name for name, fid in field_ids.items()}
+
+        if mapping is None:
+            continue
+
+        for field_id, source_name in mapping.items():
+            if field_id in current_names:
+                if source_name != current_names[field_id]:
+                    return True
+            elif source_name in current_name_set:
+                return True
+    return False
+
+
 def _has_renames(
     history: list[ColumnHistoryEntry],
     current_columns: list[ColumnInfo],
@@ -343,22 +381,122 @@ def _get_physical_type_key(
     return frozenset(diffs)
 
 
+def _get_rename_map_from_mapping(
+    name_mapping: dict[int, str],
+    current_columns: list[ColumnInfo],
+) -> dict[str, str]:
+    """Build ``{physical_name: current_name}`` from a field_id-based name mapping.
+
+    ``name_mapping`` is ``{target_field_id: source_name}`` where
+    ``target_field_id`` equals the column_id.  ``current_columns`` gives us
+    column_id → current_name at the read snapshot.  When a column has been
+    renamed, ``source_name`` (the old physical name) differs from the current
+    name, producing a rename entry.
+    """
+    current_names: dict[int, str] = {c.column_id: c.column_name for c in current_columns if c.parent_column is None}
+    current_name_set = set(current_names.values())
+    rename_map: dict[str, str] = {}
+
+    for field_id, source_name in name_mapping.items():
+        if field_id in current_names:
+            current_name = current_names[field_id]
+            if source_name != current_name:
+                rename_map[source_name] = current_name
+        else:
+            # Column was dropped — if the source_name collides with a
+            # current column name (drop+re-add), map it to a dummy.
+            if source_name in current_name_set and source_name not in rename_map:
+                rename_map[source_name] = f"__ducklake_dropped_{field_id}__"
+
+    return rename_map
+
+
+def _read_field_ids_from_parquet(file_path: str) -> dict[str, int] | None:
+    """Read ``{column_name: field_id}`` from a Parquet file's Arrow schema.
+
+    DuckDB writes ``PARQUET:field_id`` metadata on each field in the
+    Parquet schema.  Returns ``None`` if the file has no field_id metadata.
+    """
+    try:
+        import pyarrow.parquet as pq
+
+        pf = pq.ParquetFile(file_path)
+        schema = pf.schema_arrow
+        result: dict[str, int] = {}
+        for field in schema:
+            if field.metadata and b"PARQUET:field_id" in field.metadata:
+                fid = int(field.metadata[b"PARQUET:field_id"])
+                result[field.name] = fid
+        return result if result else None
+    except Exception:
+        return None
+
+
+def _get_rename_map_from_parquet_field_ids(
+    field_ids: dict[str, int],
+    current_columns: list[ColumnInfo],
+) -> dict[str, str]:
+    """Build ``{physical_name: current_name}`` from Parquet field_id metadata.
+
+    ``field_ids`` is ``{column_name_in_parquet: field_id}`` read from the
+    Parquet schema.  ``current_columns`` maps column_id → current_name.
+    """
+    current_names: dict[int, str] = {c.column_id: c.column_name for c in current_columns if c.parent_column is None}
+    current_name_set = set(current_names.values())
+    rename_map: dict[str, str] = {}
+
+    for phys_name, field_id in field_ids.items():
+        if field_id in current_names:
+            current_name = current_names[field_id]
+            if phys_name != current_name:
+                rename_map[phys_name] = current_name
+        else:
+            # Column dropped — handle name collision
+            if phys_name in current_name_set and phys_name not in rename_map:
+                rename_map[phys_name] = f"__ducklake_dropped_{field_id}__"
+
+    return rename_map
+
+
 def _group_files_by_rename_map(
     files: list[FileInfo],
     history: list[ColumnHistoryEntry],
     current_columns: list[ColumnInfo],
+    name_mappings: dict[int, dict[int, str]] | None = None,
+    resolved_paths: dict[int, str] | None = None,
 ) -> list[tuple[dict[str, str], Any, list[FileInfo]]]:
     """Group files by their rename map, struct field renames, and type changes.
 
     Returns list of (rename_map, struct_field_renames, files_list) tuples.
     struct_field_renames is ``dict[str, list[str]] | None``.
+
+    When *name_mappings* is provided (``{mapping_id: {field_id: source_name}}``),
+    files with a ``mapping_id`` use field_id-based rename detection which is
+    more reliable than the history-based fallback.
+
+    When *resolved_paths* is provided, files without a mapping_id will have
+    their Parquet schema read to extract field_id metadata for rename detection.
     """
     groups: dict[tuple, list[FileInfo]] = defaultdict(list)
     rename_maps: dict[tuple, dict[str, str]] = {}
     struct_renames_map: dict[tuple, Any] = {}
 
     for f in files:
-        rmap = _get_rename_map(f.begin_snapshot, history, current_columns)
+        rmap: dict[str, str] | None = None
+
+        # Prefer field_id mapping from catalog (ducklake_name_mapping)
+        if name_mappings and f.mapping_id is not None and f.mapping_id in name_mappings:
+            rmap = _get_rename_map_from_mapping(name_mappings[f.mapping_id], current_columns)
+        elif resolved_paths and f.data_file_id in resolved_paths:
+            # Fall back to Parquet field_id metadata
+            field_ids = _read_field_ids_from_parquet(resolved_paths[f.data_file_id])
+            if field_ids:
+                rmap = _get_rename_map_from_parquet_field_ids(field_ids, current_columns)
+
+        # Ultimate fallback: history-based rename detection
+        if rmap is None:
+            rmap = _get_rename_map(f.begin_snapshot, history, current_columns)
+
         srenames = _get_struct_field_renames(f.begin_snapshot, history, current_columns)
         type_key = _get_physical_type_key(f.begin_snapshot, history, current_columns)
 
@@ -425,12 +563,25 @@ class DuckLakeDataset:
         if self.snapshot_version is not None and self.snapshot_time is not None:
             msg = "Cannot specify both snapshot_version and snapshot_time"
             raise ValueError(msg)
+        # Persistent reader: reused between schema() and to_dataset_scan()
+        self._reader: DuckLakeCatalogReader | None = None
+        # Metadata cache: populated by schema(), consumed by to_dataset_scan()
+        self._cached_snapshot: Any = None
+        self._cached_table: TableInfo | None = None
+        self._cached_all_columns: list[ColumnInfo] | None = None
 
     def _get_reader(self) -> DuckLakeCatalogReader:
-        return DuckLakeCatalogReader(
-            self.metadata_path,
-            data_path_override=self.data_path_override,
-        )
+        if self._reader is None:
+            self._reader = DuckLakeCatalogReader(
+                self.metadata_path,
+                data_path_override=self.data_path_override,
+            )
+        return self._reader
+
+    def _close_reader(self) -> None:
+        if self._reader is not None:
+            self._reader.close()
+            self._reader = None
 
     def _resolve_snapshot(self, reader: DuckLakeCatalogReader) -> Any:
         if self.snapshot_version is not None:
@@ -438,6 +589,22 @@ class DuckLakeDataset:
         if self.snapshot_time is not None:
             return reader.get_snapshot_at_time(self.snapshot_time)
         return reader.get_current_snapshot()
+
+    def _consume_cache(self, reader: DuckLakeCatalogReader) -> tuple[Any, TableInfo, list[ColumnInfo]]:
+        """Return cached metadata if available, otherwise fetch fresh."""
+        if self._cached_snapshot is not None:
+            snapshot = self._cached_snapshot
+            table = self._cached_table
+            all_columns = self._cached_all_columns
+            # Clear cache (single use)
+            self._cached_snapshot = None
+            self._cached_table = None
+            self._cached_all_columns = None
+            return snapshot, table, all_columns  # type: ignore[return-value]
+        snapshot = self._resolve_snapshot(reader)
+        table = reader.get_table(self.table_name, self.schema_name, snapshot.snapshot_id)
+        all_columns = reader.get_all_columns(table.table_id, snapshot.snapshot_id)
+        return snapshot, table, all_columns
 
     #
     # PythonDatasetProvider interface
@@ -514,12 +681,21 @@ class DuckLakeDataset:
         return result
 
     def schema(self) -> Schema:
-        """Return the table schema as a Polars Schema."""
-        with self._get_reader() as reader:
-            snapshot = self._resolve_snapshot(reader)
-            table = reader.get_table(self.table_name, self.schema_name, snapshot.snapshot_id)
-            all_columns = reader.get_all_columns(table.table_id, snapshot.snapshot_id)
-            return pl.Schema(self._build_schema_from_columns(all_columns))
+        """Return the table schema as a Polars Schema.
+
+        Caches snapshot, table, and column metadata so that a subsequent
+        ``to_dataset_scan`` call can reuse them without re-querying the
+        catalog.
+        """
+        reader = self._get_reader()
+        snapshot = self._resolve_snapshot(reader)
+        table = reader.get_table(self.table_name, self.schema_name, snapshot.snapshot_id)
+        all_columns = reader.get_all_columns(table.table_id, snapshot.snapshot_id)
+        # Cache for reuse in to_dataset_scan()
+        self._cached_snapshot = snapshot
+        self._cached_table = table
+        self._cached_all_columns = all_columns
+        return pl.Schema(self._build_schema_from_columns(all_columns))
 
     @staticmethod
     def _build_scan_kwargs(
@@ -612,8 +788,9 @@ class DuckLakeDataset:
         """
         from polars.io.parquet.functions import scan_parquet
 
-        with self._get_reader() as reader:
-            snapshot = self._resolve_snapshot(reader)
+        reader = self._get_reader()
+        try:
+            snapshot, table, all_columns = self._consume_cache(reader)
             version_key = str(snapshot.snapshot_id)
 
             # Short-circuit if version hasn't changed
@@ -623,10 +800,6 @@ class DuckLakeDataset:
             ):
                 return None
 
-            table = reader.get_table(
-                self.table_name, self.schema_name, snapshot.snapshot_id
-            )
-            all_columns = reader.get_all_columns(table.table_id, snapshot.snapshot_id)
             columns = [c for c in all_columns if c.parent_column is None]
             column_names = [c.column_name for c in columns]
 
@@ -687,16 +860,40 @@ class DuckLakeDataset:
                     if not reader._backend.is_table_not_found(e):
                         raise
 
-            # Detect column renames and struct field renames
-            history = reader.get_column_history(table.table_id)
-            has_rename = _has_renames(history, all_columns)
+            # Resolve file paths once for reuse
+            resolved_paths: dict[int, str] = {
+                f.data_file_id: reader.resolve_data_file_path(f.path, f.path_is_relative, table)
+                for f in data_files
+            }
+
+            # Detect column renames and struct field renames.
+            # Fast path: if no column has ever been dropped/renamed
+            # (end_snapshot IS NULL for all), skip the full history fetch
+            # and the expensive Parquet field_id checks.
+            _has_col_changes = reader.has_column_changes(table.table_id)
+            name_mappings: dict[int, dict[int, str]] = {}
+            if _has_col_changes:
+                # Load field_id-based name mappings (only needed for rename detection)
+                mapping_ids_seen: set[int] = set()
+                for f in data_files:
+                    if f.mapping_id is not None and f.mapping_id not in mapping_ids_seen:
+                        mapping_ids_seen.add(f.mapping_id)
+                        name_mappings[f.mapping_id] = reader.get_name_mapping(f.mapping_id)
+
+                history = reader.get_column_history(table.table_id)
+                has_rename = _has_renames(history, all_columns)
+                if not has_rename:
+                    has_rename = _has_renames_from_mappings(
+                        data_files, name_mappings, all_columns,
+                        resolved_paths=resolved_paths,
+                    )
+            else:
+                history = []
+                has_rename = False
 
             if not has_rename:
                 # Fast path: no renames, existing code
-                sources = [
-                    reader.resolve_data_file_path(f.path, f.path_is_relative, table)
-                    for f in data_files
-                ]
+                sources = [resolved_paths[f.data_file_id] for f in data_files]
 
                 kwargs = self._build_scan_kwargs(
                     data_files, delete_files, reader, table,
@@ -710,13 +907,17 @@ class DuckLakeDataset:
                 # Parquet SCAN nodes.  We collect each file group eagerly,
                 # apply renames, write the combined result to a temporary
                 # Parquet file, and return scan_parquet on that file.
-                groups = _group_files_by_rename_map(data_files, history, all_columns)
+                groups = _group_files_by_rename_map(
+                    data_files, history, all_columns,
+                    name_mappings=name_mappings,
+                    resolved_paths=resolved_paths,
+                )
                 catalog_schema = self._build_schema_from_columns(all_columns)
 
                 group_dfs: list[pl.DataFrame] = []
                 for rename_map, struct_field_renames, group_files_list in groups:
                     sources = [
-                        reader.resolve_data_file_path(f.path, f.path_is_relative, table)
+                        resolved_paths[f.data_file_id]
                         for f in group_files_list
                     ]
 
@@ -863,3 +1064,5 @@ class DuckLakeDataset:
                 )
 
             return lf, version_key
+        finally:
+            self._close_reader()

--- a/tests/test_field_id.py
+++ b/tests/test_field_id.py
@@ -1,0 +1,93 @@
+"""Tests for field_id-based column mapping after renames."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from ducklake_polars import read_ducklake, write_ducklake
+
+
+class TestFieldIdMapping:
+    """Test that reads work correctly after column renames."""
+
+    def test_read_after_rename(self, ducklake_catalog_sqlite):
+        """Write data, rename column, write more data, read all."""
+        cat = ducklake_catalog_sqlite
+        cat.execute("CREATE TABLE ducklake.t (old_name INTEGER, value VARCHAR)")
+        cat.execute("INSERT INTO ducklake.t VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+        cat.execute("ALTER TABLE ducklake.t RENAME COLUMN old_name TO new_name")
+        cat.execute("INSERT INTO ducklake.t VALUES (4, 'd'), (5, 'e'), (6, 'f')")
+        cat.close()
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert "new_name" in result.columns
+        assert "old_name" not in result.columns
+        assert result.shape[0] == 6
+        assert sorted(result["new_name"].to_list()) == [1, 2, 3, 4, 5, 6]
+
+    def test_read_after_multiple_renames(self, ducklake_catalog_sqlite):
+        """Column renamed twice — reads should use final name."""
+        cat = ducklake_catalog_sqlite
+        cat.execute("CREATE TABLE ducklake.t (col_a INTEGER)")
+        cat.execute("INSERT INTO ducklake.t VALUES (1), (2)")
+        cat.execute("ALTER TABLE ducklake.t RENAME COLUMN col_a TO col_b")
+        cat.execute("INSERT INTO ducklake.t VALUES (3), (4)")
+        cat.execute("ALTER TABLE ducklake.t RENAME COLUMN col_b TO col_c")
+        cat.execute("INSERT INTO ducklake.t VALUES (5), (6)")
+        cat.close()
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert "col_c" in result.columns
+        assert "col_a" not in result.columns
+        assert "col_b" not in result.columns
+        assert result.shape[0] == 6
+        assert sorted(result["col_c"].to_list()) == [1, 2, 3, 4, 5, 6]
+
+    def test_rename_with_multiple_columns(self, ducklake_catalog_sqlite):
+        """Rename one column out of several — others stay the same."""
+        cat = ducklake_catalog_sqlite
+        cat.execute("CREATE TABLE ducklake.t (x INTEGER, y VARCHAR, z DOUBLE)")
+        cat.execute("INSERT INTO ducklake.t VALUES (1, 'a', 1.0), (2, 'b', 2.0)")
+        cat.execute("ALTER TABLE ducklake.t RENAME COLUMN x TO renamed_x")
+        cat.execute("INSERT INTO ducklake.t VALUES (3, 'c', 3.0)")
+        cat.close()
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert "renamed_x" in result.columns
+        assert "x" not in result.columns
+        assert "y" in result.columns
+        assert "z" in result.columns
+        assert result.shape[0] == 3
+        assert sorted(result["renamed_x"].to_list()) == [1, 2, 3]
+
+    def test_no_rename_fast_path(self, ducklake_catalog_sqlite):
+        """No renames — field_id mapping shouldn't break fast path."""
+        cat = ducklake_catalog_sqlite
+        cat.execute("CREATE TABLE ducklake.t (a INTEGER, b VARCHAR)")
+        cat.execute("INSERT INTO ducklake.t VALUES (1, 'x'), (2, 'y')")
+        cat.execute("INSERT INTO ducklake.t VALUES (3, 'z')")
+        cat.close()
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert result.shape[0] == 3
+        assert sorted(result.columns) == ["a", "b"]
+
+    def test_duckdb_rename_then_read_with_polars(self, ducklake_catalog_sqlite):
+        """DuckDB creates, renames, inserts — ducklake-dataframe reads correctly."""
+        cat = ducklake_catalog_sqlite
+        cat.execute("CREATE TABLE ducklake.t (x INTEGER, y VARCHAR)")
+        cat.execute("INSERT INTO ducklake.t VALUES (1, 'a'), (2, 'b')")
+        cat.execute("ALTER TABLE ducklake.t RENAME COLUMN x TO z")
+        cat.execute("INSERT INTO ducklake.t VALUES (3, 'c')")
+
+        # Verify DuckDB sees it correctly
+        duckdb_result = cat.execute("SELECT * FROM ducklake.t ORDER BY z").fetchall()
+        assert duckdb_result == [(1, 'a'), (2, 'b'), (3, 'c')]
+        cat.close()
+
+        # Now read with ducklake-dataframe
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert "z" in result.columns
+        assert "x" not in result.columns
+        assert result.shape[0] == 3
+        assert sorted(result["z"].to_list()) == [1, 2, 3]


### PR DESCRIPTION
## Summary
Implements field_id-based column mapping matching DuckDB's DuckLake behavior.

When columns are renamed, old Parquet files still contain the old column name. DuckDB uses `ducklake_name_mapping` (target_field_id → source_name) to correctly map physical names to current catalog names.

## Changes
- `_catalog.py`: `get_name_mapping(mapping_id)` queries ducklake_name_mapping
- `_dataset.py`: field_id-based rename detection + mapping from name_mapping table and Parquet metadata
- Falls back to history-based rename detection (existing behavior)

## Tests
5 new tests: single rename, multiple renames, multi-column rename, no-rename fast path, DuckDB interop
1478 tests passing