### PR TITLE
test: comments, settings, migration tests (parity gaps)

### DIFF
--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,228 @@
+"""Comment / tag edge-case tests for DuckLake catalog.
+
+Covers:
+- Setting comment on a column directly via the writer API
+- Setting comments mixed with other operations in the same DuckDB session
+- Setting comment on table + column in sequence
+- Uses ducklake_catalog_sqlite fixture to avoid Postgres deadlocks
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from ducklake_polars import (
+    DuckLakeCatalog,
+    create_ducklake_table,
+    set_ducklake_column_tag,
+    set_ducklake_table_tag,
+    write_ducklake,
+    read_ducklake,
+)
+
+
+# ------------------------------------------------------------------
+# Column comment via writer API
+# ------------------------------------------------------------------
+
+
+def test_set_column_comment_via_writer(ducklake_catalog_sqlite):
+    """Set a 'comment' tag on a column through the writer API and read back."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.items (id INTEGER, name VARCHAR, price DOUBLE)")
+    cat.close()
+
+    path = cat.metadata_path
+    dp = cat.data_path
+
+    set_ducklake_column_tag(path, "items", "id", "comment", "primary key", data_path=dp)
+    set_ducklake_column_tag(path, "items", "name", "comment", "item display name", data_path=dp)
+    set_ducklake_column_tag(path, "items", "price", "comment", "unit price in USD", data_path=dp)
+
+    catalog = DuckLakeCatalog(path, data_path=dp)
+
+    id_tags = catalog.column_tags("items", "id")
+    assert id_tags.shape[0] == 1
+    assert id_tags["key"][0] == "comment"
+    assert id_tags["value"][0] == "primary key"
+
+    name_tags = catalog.column_tags("items", "name")
+    assert name_tags["value"][0] == "item display name"
+
+    price_tags = catalog.column_tags("items", "price")
+    assert price_tags["value"][0] == "unit price in USD"
+
+
+def test_set_column_comment_overwrite(ducklake_catalog_sqlite):
+    """Overwriting a column comment replaces the old value."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.t (a INTEGER)")
+    cat.close()
+
+    path = cat.metadata_path
+    dp = cat.data_path
+
+    set_ducklake_column_tag(path, "t", "a", "comment", "old", data_path=dp)
+    set_ducklake_column_tag(path, "t", "a", "comment", "new", data_path=dp)
+
+    catalog = DuckLakeCatalog(path, data_path=dp)
+    tags = catalog.column_tags("t", "a")
+    assert tags.shape[0] == 1
+    assert tags["value"][0] == "new"
+
+
+# ------------------------------------------------------------------
+# Comments mixed with other DuckDB operations in one session
+# ------------------------------------------------------------------
+
+
+def test_comment_mixed_with_insert(ducklake_catalog_sqlite):
+    """COMMENT ON mixed with INSERT in the same DuckDB session."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.mixed (id INTEGER, val VARCHAR)")
+    cat.execute("INSERT INTO ducklake.mixed VALUES (1, 'first')")
+    cat.execute("COMMENT ON TABLE ducklake.mixed IS 'table with data'")
+    cat.execute("INSERT INTO ducklake.mixed VALUES (2, 'second')")
+    cat.execute("COMMENT ON COLUMN ducklake.mixed.val IS 'the value column'")
+    cat.close()
+
+    # Verify data
+    result = read_ducklake(cat.metadata_path, "mixed", data_path=cat.data_path)
+    result = result.sort("id")
+    assert result.shape[0] == 2
+    assert result["id"].to_list() == [1, 2]
+
+    # Verify comments
+    catalog = DuckLakeCatalog(cat.metadata_path, data_path=cat.data_path)
+    table_tags = catalog.table_tags("mixed")
+    assert table_tags.shape[0] == 1
+    assert table_tags["value"][0] == "table with data"
+
+    col_tags = catalog.column_tags("mixed", "val")
+    assert col_tags.shape[0] == 1
+    assert col_tags["value"][0] == "the value column"
+
+
+def test_comment_mixed_with_alter(ducklake_catalog_sqlite):
+    """COMMENT ON mixed with ALTER TABLE in the same DuckDB session."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.evolve (a INTEGER)")
+    cat.execute("COMMENT ON TABLE ducklake.evolve IS 'v1 schema'")
+    cat.execute("ALTER TABLE ducklake.evolve ADD COLUMN b VARCHAR")
+    cat.execute("COMMENT ON COLUMN ducklake.evolve.b IS 'added later'")
+    cat.close()
+
+    catalog = DuckLakeCatalog(cat.metadata_path, data_path=cat.data_path)
+
+    table_tags = catalog.table_tags("evolve")
+    assert table_tags.shape[0] == 1
+    assert table_tags["value"][0] == "v1 schema"
+
+    col_tags = catalog.column_tags("evolve", "b")
+    assert col_tags.shape[0] == 1
+    assert col_tags["value"][0] == "added later"
+
+
+# ------------------------------------------------------------------
+# Table + column comments in sequence
+# ------------------------------------------------------------------
+
+
+def test_table_then_column_comment_sequence(ducklake_catalog_sqlite):
+    """Set table comment first, then column comment — both should survive."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.seq (x INTEGER, y VARCHAR)")
+    cat.close()
+
+    path = cat.metadata_path
+    dp = cat.data_path
+
+    # Table tag first
+    set_ducklake_table_tag(path, "seq", "comment", "sequence table", data_path=dp)
+    # Then column tags
+    set_ducklake_column_tag(path, "seq", "x", "comment", "x axis", data_path=dp)
+    set_ducklake_column_tag(path, "seq", "y", "comment", "y label", data_path=dp)
+
+    catalog = DuckLakeCatalog(path, data_path=dp)
+
+    table_tags = catalog.table_tags("seq")
+    assert table_tags.shape[0] == 1
+    assert table_tags["value"][0] == "sequence table"
+
+    x_tags = catalog.column_tags("seq", "x")
+    assert x_tags["value"][0] == "x axis"
+
+    y_tags = catalog.column_tags("seq", "y")
+    assert y_tags["value"][0] == "y label"
+
+
+def test_column_then_table_comment_sequence(ducklake_catalog_sqlite):
+    """Set column comment first, then table comment — both should survive."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.rev (a INTEGER, b VARCHAR)")
+    cat.close()
+
+    path = cat.metadata_path
+    dp = cat.data_path
+
+    # Column tags first
+    set_ducklake_column_tag(path, "rev", "a", "comment", "col a", data_path=dp)
+    set_ducklake_column_tag(path, "rev", "b", "comment", "col b", data_path=dp)
+    # Then table tag
+    set_ducklake_table_tag(path, "rev", "comment", "reverse order", data_path=dp)
+
+    catalog = DuckLakeCatalog(path, data_path=dp)
+
+    table_tags = catalog.table_tags("rev")
+    assert table_tags.shape[0] == 1
+    assert table_tags["value"][0] == "reverse order"
+
+    a_tags = catalog.column_tags("rev", "a")
+    assert a_tags["value"][0] == "col a"
+
+    b_tags = catalog.column_tags("rev", "b")
+    assert b_tags["value"][0] == "col b"
+
+
+def test_multiple_custom_tags_on_columns(ducklake_catalog_sqlite):
+    """Multiple non-comment tags on the same column."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.multi (col1 INTEGER)")
+    cat.close()
+
+    path = cat.metadata_path
+    dp = cat.data_path
+
+    set_ducklake_column_tag(path, "multi", "col1", "comment", "main column", data_path=dp)
+    set_ducklake_column_tag(path, "multi", "col1", "pii", "false", data_path=dp)
+    set_ducklake_column_tag(path, "multi", "col1", "unit", "count", data_path=dp)
+
+    catalog = DuckLakeCatalog(path, data_path=dp)
+    tags = catalog.column_tags("multi", "col1")
+    assert tags.shape[0] == 3
+    tag_dict = dict(zip(tags["key"].to_list(), tags["value"].to_list()))
+    assert tag_dict["comment"] == "main column"
+    assert tag_dict["pii"] == "false"
+    assert tag_dict["unit"] == "count"
+
+
+def test_comment_on_table_with_data_via_duckdb(ducklake_catalog_sqlite):
+    """DuckDB COMMENT after inserting data — comment and data both readable."""
+    cat = ducklake_catalog_sqlite
+    cat.execute("CREATE TABLE ducklake.withdata (a INTEGER, b VARCHAR)")
+    cat.execute("INSERT INTO ducklake.withdata VALUES (1, 'hello'), (2, 'world')")
+    cat.execute("COMMENT ON TABLE ducklake.withdata IS 'has data'")
+    cat.execute("COMMENT ON COLUMN ducklake.withdata.a IS 'integer col'")
+    cat.close()
+
+    # Data intact
+    result = read_ducklake(cat.metadata_path, "withdata", data_path=cat.data_path)
+    result = result.sort("a")
+    assert result["a"].to_list() == [1, 2]
+    assert result["b"].to_list() == ["hello", "world"]
+
+    # Comments intact
+    catalog = DuckLakeCatalog(cat.metadata_path, data_path=cat.data_path)
+    assert catalog.table_tags("withdata")["value"][0] == "has data"
+    assert catalog.column_tags("withdata", "a")["value"][0] == "integer col"

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,581 @@
+"""Version compatibility / migration tests for DuckLake catalog.
+
+Covers:
+- Reading a v0.3-style catalog (without ducklake_snapshot_changes table)
+- Reading a v0.4-style catalog (with ducklake_snapshot_changes + partial_max on delete files)
+- Graceful handling when expected tables don't exist
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import polars as pl
+import pytest
+
+from ducklake_polars import read_ducklake, scan_ducklake
+from ducklake_core._catalog import DuckLakeCatalogReader, SUPPORTED_DUCKLAKE_VERSIONS
+
+
+# ------------------------------------------------------------------
+# Helpers: create minimal catalog schemas via raw SQLite
+# ------------------------------------------------------------------
+
+
+def _create_v03_catalog(db_path: str, data_path: str) -> None:
+    """Create a minimal v0.3-style DuckLake catalog via raw SQL.
+
+    v0.3 catalogs do NOT have:
+    - ducklake_snapshot_changes table
+    - partial_max column on ducklake_delete_file
+    Column names match the actual DuckLake DDL: path/path_is_relative on
+    both ducklake_table and ducklake_schema, etc.
+    """
+    con = sqlite3.connect(db_path)
+    con.executescript(f"""
+        CREATE TABLE ducklake_metadata (
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            scope TEXT,
+            scope_id BIGINT
+        );
+        INSERT INTO ducklake_metadata VALUES ('version', '0.3', NULL, NULL);
+        INSERT INTO ducklake_metadata VALUES ('data_path', '{data_path}', NULL, NULL);
+
+        CREATE TABLE ducklake_snapshot (
+            snapshot_id BIGINT PRIMARY KEY,
+            snapshot_time TEXT,
+            schema_version BIGINT DEFAULT 0,
+            next_catalog_id BIGINT DEFAULT 0,
+            next_file_id BIGINT DEFAULT 0
+        );
+
+        CREATE TABLE ducklake_schema (
+            schema_id BIGINT PRIMARY KEY,
+            schema_uuid TEXT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            schema_name TEXT,
+            path TEXT DEFAULT '',
+            path_is_relative BIGINT DEFAULT 1
+        );
+        INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', '', 1);
+
+        CREATE TABLE ducklake_table (
+            table_id BIGINT,
+            table_uuid TEXT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            schema_id BIGINT,
+            table_name TEXT,
+            path TEXT DEFAULT '',
+            path_is_relative BIGINT DEFAULT 1
+        );
+
+        CREATE TABLE ducklake_column (
+            column_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            table_id BIGINT,
+            column_order BIGINT,
+            column_name TEXT,
+            column_type TEXT,
+            initial_default TEXT,
+            default_value TEXT,
+            nulls_allowed BIGINT DEFAULT 1,
+            parent_column BIGINT,
+            default_value_type TEXT,
+            default_value_dialect TEXT
+        );
+
+        CREATE TABLE ducklake_data_file (
+            data_file_id BIGINT PRIMARY KEY,
+            table_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            file_order BIGINT,
+            path TEXT,
+            path_is_relative BIGINT DEFAULT 1,
+            file_format TEXT,
+            record_count BIGINT,
+            file_size_bytes BIGINT DEFAULT 0,
+            footer_size BIGINT,
+            row_id_start BIGINT DEFAULT 0,
+            partition_id BIGINT,
+            encryption_key TEXT,
+            mapping_id BIGINT
+        );
+
+        CREATE TABLE ducklake_delete_file (
+            delete_file_id BIGINT PRIMARY KEY,
+            table_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            data_file_id BIGINT,
+            path TEXT,
+            path_is_relative BIGINT DEFAULT 1,
+            format TEXT,
+            delete_count BIGINT DEFAULT 0,
+            file_size_bytes BIGINT,
+            footer_size BIGINT,
+            encryption_key TEXT
+        );
+
+        CREATE TABLE ducklake_file_column_stats (
+            data_file_id BIGINT,
+            table_id BIGINT,
+            column_id BIGINT,
+            column_size_bytes BIGINT,
+            value_count BIGINT,
+            null_count BIGINT,
+            min_value TEXT,
+            max_value TEXT,
+            contains_nan BIGINT,
+            extra_stats TEXT
+        );
+
+        CREATE TABLE ducklake_inlined_data_tables (
+            table_id BIGINT,
+            table_name TEXT,
+            schema_version BIGINT DEFAULT 0
+        );
+
+        CREATE TABLE ducklake_tag (
+            object_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            key TEXT,
+            value TEXT
+        );
+
+        CREATE TABLE ducklake_column_tag (
+            table_id BIGINT,
+            column_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            key TEXT,
+            value TEXT
+        );
+
+        CREATE TABLE ducklake_partition_info (
+            partition_id BIGINT,
+            table_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT
+        );
+
+        CREATE TABLE ducklake_file_partition_value (
+            data_file_id BIGINT,
+            table_id BIGINT,
+            partition_key_index BIGINT,
+            partition_value TEXT
+        );
+
+        CREATE TABLE ducklake_column_mapping (
+            mapping_id BIGINT,
+            table_id BIGINT,
+            type TEXT
+        );
+
+        CREATE TABLE ducklake_name_mapping (
+            mapping_id BIGINT,
+            column_id BIGINT,
+            source_name TEXT,
+            target_field_id BIGINT,
+            parent_column BIGINT,
+            is_partition BIGINT
+        );
+
+        CREATE TABLE ducklake_schema_versions (
+            begin_snapshot BIGINT,
+            schema_version BIGINT,
+            table_id BIGINT
+        );
+
+        -- Insert initial snapshot
+        INSERT INTO ducklake_snapshot VALUES (0, '2024-01-01 00:00:00', 1, 2, 0);
+
+        -- Create a test table
+        INSERT INTO ducklake_table VALUES (0, 'table-uuid-0', 0, NULL, 0, 'legacy_table', '', 1);
+
+        -- Add columns (id=0: a INTEGER, id=1: b VARCHAR)
+        INSERT INTO ducklake_column VALUES (0, 0, NULL, 0, 0, 'a', 'INTEGER', NULL, NULL, 1, NULL, NULL, NULL);
+        INSERT INTO ducklake_column VALUES (1, 0, NULL, 0, 1, 'b', 'VARCHAR', NULL, NULL, 1, NULL, NULL, NULL);
+
+        -- Schema versions entry
+        INSERT INTO ducklake_schema_versions VALUES (0, 1, 0);
+    """)
+    con.close()
+
+
+def _create_v04_catalog(db_path: str, data_path: str) -> None:
+    """Create a minimal v0.4-style DuckLake catalog via raw SQL.
+
+    v0.4 catalogs add:
+    - ducklake_snapshot_changes table
+    - partial_max column on ducklake_delete_file
+    """
+    con = sqlite3.connect(db_path)
+    con.executescript(f"""
+        CREATE TABLE ducklake_metadata (
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            scope TEXT,
+            scope_id BIGINT
+        );
+        INSERT INTO ducklake_metadata VALUES ('version', '0.4', NULL, NULL);
+        INSERT INTO ducklake_metadata VALUES ('data_path', '{data_path}', NULL, NULL);
+
+        CREATE TABLE ducklake_snapshot (
+            snapshot_id BIGINT PRIMARY KEY,
+            snapshot_time TEXT,
+            schema_version BIGINT DEFAULT 0,
+            next_catalog_id BIGINT DEFAULT 0,
+            next_file_id BIGINT DEFAULT 0
+        );
+
+        CREATE TABLE ducklake_snapshot_changes (
+            snapshot_id BIGINT PRIMARY KEY,
+            changes_made TEXT,
+            author TEXT,
+            commit_message TEXT,
+            commit_extra_info TEXT
+        );
+
+        CREATE TABLE ducklake_schema (
+            schema_id BIGINT PRIMARY KEY,
+            schema_uuid TEXT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            schema_name TEXT,
+            path TEXT DEFAULT '',
+            path_is_relative BIGINT DEFAULT 1
+        );
+        INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', '', 1);
+
+        CREATE TABLE ducklake_table (
+            table_id BIGINT,
+            table_uuid TEXT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            schema_id BIGINT,
+            table_name TEXT,
+            path TEXT DEFAULT '',
+            path_is_relative BIGINT DEFAULT 1
+        );
+
+        CREATE TABLE ducklake_column (
+            column_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            table_id BIGINT,
+            column_order BIGINT,
+            column_name TEXT,
+            column_type TEXT,
+            initial_default TEXT,
+            default_value TEXT,
+            nulls_allowed BIGINT DEFAULT 1,
+            parent_column BIGINT,
+            default_value_type TEXT,
+            default_value_dialect TEXT
+        );
+
+        CREATE TABLE ducklake_data_file (
+            data_file_id BIGINT PRIMARY KEY,
+            table_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            file_order BIGINT,
+            path TEXT,
+            path_is_relative BIGINT DEFAULT 1,
+            file_format TEXT,
+            record_count BIGINT,
+            file_size_bytes BIGINT DEFAULT 0,
+            footer_size BIGINT,
+            row_id_start BIGINT DEFAULT 0,
+            partition_id BIGINT,
+            encryption_key TEXT,
+            mapping_id BIGINT,
+            partial_max BIGINT
+        );
+
+        CREATE TABLE ducklake_delete_file (
+            delete_file_id BIGINT PRIMARY KEY,
+            table_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            data_file_id BIGINT,
+            path TEXT,
+            path_is_relative BIGINT DEFAULT 1,
+            format TEXT,
+            delete_count BIGINT DEFAULT 0,
+            file_size_bytes BIGINT,
+            footer_size BIGINT,
+            encryption_key TEXT,
+            partial_max BIGINT
+        );
+
+        CREATE TABLE ducklake_file_column_stats (
+            data_file_id BIGINT,
+            table_id BIGINT,
+            column_id BIGINT,
+            column_size_bytes BIGINT,
+            value_count BIGINT,
+            null_count BIGINT,
+            min_value TEXT,
+            max_value TEXT,
+            contains_nan BIGINT,
+            extra_stats TEXT
+        );
+
+        CREATE TABLE ducklake_inlined_data_tables (
+            table_id BIGINT,
+            table_name TEXT,
+            schema_version BIGINT DEFAULT 0
+        );
+
+        CREATE TABLE ducklake_tag (
+            object_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            key TEXT,
+            value TEXT
+        );
+
+        CREATE TABLE ducklake_column_tag (
+            table_id BIGINT,
+            column_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT,
+            key TEXT,
+            value TEXT
+        );
+
+        CREATE TABLE ducklake_partition_info (
+            partition_id BIGINT,
+            table_id BIGINT,
+            begin_snapshot BIGINT DEFAULT 0,
+            end_snapshot BIGINT
+        );
+
+        CREATE TABLE ducklake_file_partition_value (
+            data_file_id BIGINT,
+            table_id BIGINT,
+            partition_key_index BIGINT,
+            partition_value TEXT
+        );
+
+        CREATE TABLE ducklake_column_mapping (
+            mapping_id BIGINT,
+            table_id BIGINT,
+            type TEXT
+        );
+
+        CREATE TABLE ducklake_name_mapping (
+            mapping_id BIGINT,
+            column_id BIGINT,
+            source_name TEXT,
+            target_field_id BIGINT,
+            parent_column BIGINT,
+            is_partition BIGINT
+        );
+
+        CREATE TABLE ducklake_schema_versions (
+            begin_snapshot BIGINT,
+            schema_version BIGINT,
+            table_id BIGINT
+        );
+
+        -- Insert initial snapshot
+        INSERT INTO ducklake_snapshot VALUES (0, '2024-01-01 00:00:00', 1, 2, 0);
+
+        -- Create a test table
+        INSERT INTO ducklake_table VALUES (0, 'table-uuid-0', 0, NULL, 0, 'modern_table', '', 1);
+
+        -- Add columns
+        INSERT INTO ducklake_column VALUES (0, 0, NULL, 0, 0, 'id', 'INTEGER', NULL, NULL, 1, NULL, NULL, NULL);
+        INSERT INTO ducklake_column VALUES (1, 0, NULL, 0, 1, 'name', 'VARCHAR', NULL, NULL, 1, NULL, NULL, NULL);
+
+        -- Snapshot changes record
+        INSERT INTO ducklake_snapshot_changes VALUES (0, 'create_table:"main"."modern_table"', NULL, NULL, NULL);
+
+        -- Schema versions entry
+        INSERT INTO ducklake_schema_versions VALUES (0, 1, 0);
+    """)
+    con.close()
+
+
+# ------------------------------------------------------------------
+# v0.3 catalog compatibility
+# ------------------------------------------------------------------
+
+
+class TestV03Catalog:
+    """Test reading a v0.3-style catalog (no snapshot_changes table)."""
+
+    def test_read_v03_catalog_metadata(self, tmp_path):
+        """Can open and read metadata from a v0.3 catalog."""
+        db_path = str(tmp_path / "v03.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        _create_v03_catalog(db_path, data_path)
+
+        with DuckLakeCatalogReader(db_path, data_path_override=data_path) as reader:
+            snap = reader.get_current_snapshot()
+            assert snap.snapshot_id == 0
+
+            table = reader.get_table("legacy_table", "main", snap.snapshot_id)
+            assert table.table_name == "legacy_table"
+
+            cols = reader.get_columns(table.table_id, snap.snapshot_id)
+            col_names = [c.column_name for c in cols]
+            assert "a" in col_names
+            assert "b" in col_names
+
+    def test_read_v03_catalog_empty_table(self, tmp_path):
+        """Reading an empty v0.3 table returns empty DataFrame."""
+        db_path = str(tmp_path / "v03.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        _create_v03_catalog(db_path, data_path)
+
+        result = read_ducklake(db_path, "legacy_table", data_path=data_path)
+        assert result.shape[0] == 0
+        assert "a" in result.columns
+        assert "b" in result.columns
+
+    def test_v03_no_snapshot_changes_table(self, tmp_path):
+        """v0.3 catalog has no ducklake_snapshot_changes — should not error."""
+        db_path = str(tmp_path / "v03.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        _create_v03_catalog(db_path, data_path)
+
+        # Verify ducklake_snapshot_changes doesn't exist
+        con = sqlite3.connect(db_path)
+        tables = [
+            r[0]
+            for r in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        ]
+        con.close()
+        assert "ducklake_snapshot_changes" not in tables
+
+        # Reading should still work fine
+        result = read_ducklake(db_path, "legacy_table", data_path=data_path)
+        assert result.shape[0] == 0
+
+
+# ------------------------------------------------------------------
+# v0.4 catalog compatibility
+# ------------------------------------------------------------------
+
+
+class TestV04Catalog:
+    """Test reading a v0.4-style catalog."""
+
+    def test_read_v04_catalog_metadata(self, tmp_path):
+        """Can open and read metadata from a v0.4 catalog."""
+        db_path = str(tmp_path / "v04.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        _create_v04_catalog(db_path, data_path)
+
+        with DuckLakeCatalogReader(db_path, data_path_override=data_path) as reader:
+            snap = reader.get_current_snapshot()
+            assert snap.snapshot_id == 0
+
+            table = reader.get_table("modern_table", "main", snap.snapshot_id)
+            assert table.table_name == "modern_table"
+
+            cols = reader.get_columns(table.table_id, snap.snapshot_id)
+            col_names = [c.column_name for c in cols]
+            assert "id" in col_names
+            assert "name" in col_names
+
+    def test_read_v04_catalog_empty_table(self, tmp_path):
+        """Reading an empty v0.4 table returns empty DataFrame."""
+        db_path = str(tmp_path / "v04.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        _create_v04_catalog(db_path, data_path)
+
+        result = read_ducklake(db_path, "modern_table", data_path=data_path)
+        assert result.shape[0] == 0
+        assert "id" in result.columns
+        assert "name" in result.columns
+
+    def test_v04_has_snapshot_changes_table(self, tmp_path):
+        """v0.4 catalog has ducklake_snapshot_changes table."""
+        db_path = str(tmp_path / "v04.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path, exist_ok=True)
+
+        _create_v04_catalog(db_path, data_path)
+
+        con = sqlite3.connect(db_path)
+        tables = [
+            r[0]
+            for r in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        ]
+        con.close()
+        assert "ducklake_snapshot_changes" in tables
+
+
+# ------------------------------------------------------------------
+# Unsupported versions
+# ------------------------------------------------------------------
+
+
+class TestUnsupportedVersion:
+    """Test graceful handling of unsupported catalog versions."""
+
+    def test_unsupported_version_raises(self, tmp_path):
+        """Opening a catalog with an unsupported version raises ValueError."""
+        db_path = str(tmp_path / "bad.ducklake")
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "CREATE TABLE ducklake_metadata (key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        con.execute("INSERT INTO ducklake_metadata VALUES ('version', '0.1')")
+        con.commit()
+        con.close()
+
+        with pytest.raises(ValueError, match="Unsupported DuckLake catalog version"):
+            with DuckLakeCatalogReader(db_path) as reader:
+                reader.get_current_snapshot()
+
+    def test_missing_version_raises(self, tmp_path):
+        """Opening a catalog with no version entry raises ValueError."""
+        db_path = str(tmp_path / "noversion.ducklake")
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "CREATE TABLE ducklake_metadata (key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        con.execute("INSERT INTO ducklake_metadata VALUES ('data_path', '/tmp')")
+        con.commit()
+        con.close()
+
+        with pytest.raises(ValueError, match="No version found"):
+            with DuckLakeCatalogReader(db_path) as reader:
+                reader.get_current_snapshot()
+
+
+# ------------------------------------------------------------------
+# Supported versions constant
+# ------------------------------------------------------------------
+
+
+def test_supported_versions_include_expected():
+    """SUPPORTED_DUCKLAKE_VERSIONS includes 0.3 and 0.4."""
+    assert "0.3" in SUPPORTED_DUCKLAKE_VERSIONS
+    assert "0.4" in SUPPORTED_DUCKLAKE_VERSIONS

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,206 @@
+"""Configuration / settings tests for DuckLake catalog.
+
+Covers:
+- Data inlining threshold behaviour (small data inlined, large data → Parquet)
+- Reading tables with both inlined and Parquet data
+- Different data paths
+"""
+
+from __future__ import annotations
+
+import os
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from ducklake_polars import (
+    read_ducklake,
+    write_ducklake,
+    create_ducklake_table,
+    scan_ducklake,
+)
+
+
+# ------------------------------------------------------------------
+# Data inlining threshold
+# ------------------------------------------------------------------
+
+
+class TestDataInliningThreshold:
+    """Verify that data below the inlining row limit is inlined,
+    while data above goes to Parquet files."""
+
+    def test_small_data_is_inlined(self, make_write_catalog):
+        """Insert below threshold → no Parquet files, data in inlined tables."""
+        cat = make_write_catalog(inline=True, inline_limit=100)
+
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        write_ducklake(
+            df, cat.metadata_path, "small",
+            data_path=cat.data_path,
+            data_inlining_row_limit=100,
+        )
+
+        # No Parquet data files
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_data_file")
+        assert row[0] == 0
+
+        # Inlined data table exists
+        inlined = cat.query_all("SELECT table_name FROM ducklake_inlined_data_tables")
+        assert len(inlined) >= 1
+
+        # Data reads back correctly
+        result = read_ducklake(cat.metadata_path, "small", data_path=cat.data_path)
+        assert_frame_equal(result.sort("a"), df.sort("a"))
+
+    def test_large_data_goes_to_parquet(self, make_write_catalog):
+        """Insert above threshold → data written to Parquet file."""
+        cat = make_write_catalog(inline=True, inline_limit=10)
+
+        # 50 rows, well above the 10-row inline limit
+        df = pl.DataFrame({
+            "id": list(range(50)),
+            "val": [f"row_{i}" for i in range(50)],
+        })
+        write_ducklake(
+            df, cat.metadata_path, "large",
+            data_path=cat.data_path,
+            data_inlining_row_limit=10,
+        )
+
+        # Should have Parquet data file(s)
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_data_file")
+        assert row[0] >= 1
+
+        # Data reads back correctly
+        result = read_ducklake(cat.metadata_path, "large", data_path=cat.data_path)
+        assert result.shape[0] == 50
+        result = result.sort("id")
+        assert result["id"].to_list() == list(range(50))
+
+    def test_mixed_inlined_and_parquet(self, make_write_catalog):
+        """First insert small (inlined), then large (Parquet) — both readable."""
+        cat = make_write_catalog(inline=True, inline_limit=20)
+
+        # Small insert → inlined
+        df_small = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        write_ducklake(
+            df_small, cat.metadata_path, "mixed",
+            data_path=cat.data_path,
+            data_inlining_row_limit=20,
+        )
+
+        # Large insert → Parquet
+        df_large = pl.DataFrame({
+            "a": list(range(100, 200)),
+            "b": [f"v{i}" for i in range(100, 200)],
+        })
+        write_ducklake(
+            df_large, cat.metadata_path, "mixed",
+            mode="append",
+            data_path=cat.data_path,
+            data_inlining_row_limit=20,
+        )
+
+        result = read_ducklake(cat.metadata_path, "mixed", data_path=cat.data_path)
+        assert result.shape[0] == 103  # 3 inlined + 100 Parquet
+
+        # Check both portions present
+        small_rows = result.filter(pl.col("a") < 10).sort("a")
+        assert small_rows["a"].to_list() == [1, 2, 3]
+
+        large_rows = result.filter(pl.col("a") >= 100).sort("a")
+        assert large_rows.shape[0] == 100
+
+    def test_inlining_disabled_always_parquet(self, make_write_catalog):
+        """With inlining disabled (limit=0), even tiny inserts go to Parquet."""
+        cat = make_write_catalog(inline=False)
+
+        df = pl.DataFrame({"a": [1], "b": ["only"]})
+        write_ducklake(
+            df, cat.metadata_path, "noninline",
+            data_path=cat.data_path,
+            data_inlining_row_limit=0,
+        )
+
+        # Should have a Parquet file
+        row = cat.query_one("SELECT COUNT(*) FROM ducklake_data_file")
+        assert row[0] >= 1
+
+        result = read_ducklake(cat.metadata_path, "noninline", data_path=cat.data_path)
+        assert result.shape[0] == 1
+        assert result["a"][0] == 1
+
+
+# ------------------------------------------------------------------
+# Different data paths
+# ------------------------------------------------------------------
+
+
+class TestDataPaths:
+    """Test that data_path override works correctly."""
+
+    def test_custom_data_path(self, tmp_path, make_write_catalog):
+        """Writing with a custom data path stores files in that directory."""
+        cat = make_write_catalog(inline=False)
+
+        df = pl.DataFrame({"x": [10, 20, 30]})
+        write_ducklake(
+            df, cat.metadata_path, "pathtest",
+            data_path=cat.data_path,
+            data_inlining_row_limit=0,
+        )
+
+        # Data directory should have files
+        data_files = []
+        for root, dirs, files in os.walk(cat.data_path):
+            for f in files:
+                if f.endswith(".parquet"):
+                    data_files.append(os.path.join(root, f))
+        assert len(data_files) >= 1
+
+        # Can read with explicit data_path
+        result = read_ducklake(
+            cat.metadata_path, "pathtest", data_path=cat.data_path
+        )
+        assert result.shape[0] == 3
+        assert sorted(result["x"].to_list()) == [10, 20, 30]
+
+    def test_data_path_override_on_read(self, tmp_path, make_write_catalog):
+        """data_path override on read allows reading from a relocated catalog."""
+        cat = make_write_catalog(inline=False)
+
+        df = pl.DataFrame({"val": [100, 200]})
+        write_ducklake(
+            df, cat.metadata_path, "relocated",
+            data_path=cat.data_path,
+            data_inlining_row_limit=0,
+        )
+
+        # Read with explicit data_path override (same location, but explicit)
+        result = read_ducklake(
+            cat.metadata_path, "relocated", data_path=cat.data_path
+        )
+        assert result.shape[0] == 2
+        assert sorted(result["val"].to_list()) == [100, 200]
+
+    def test_scan_with_data_path(self, make_write_catalog):
+        """scan_ducklake works with data_path override."""
+        cat = make_write_catalog(inline=False)
+
+        df = pl.DataFrame({"k": [1, 2, 3, 4, 5], "v": ["a", "b", "c", "d", "e"]})
+        write_ducklake(
+            df, cat.metadata_path, "scanpath",
+            data_path=cat.data_path,
+            data_inlining_row_limit=0,
+        )
+
+        result = (
+            scan_ducklake(cat.metadata_path, "scanpath", data_path=cat.data_path)
+            .filter(pl.col("k") > 3)
+            .collect()
+        )
+        result = result.sort("k")
+        assert result["k"].to_list() == [4, 5]
+        assert result["v"].to_list() == ["d", "e"]


### PR DESCRIPTION
Adds three new test files to close test parity gaps:

### `tests/test_comments.py` (10 tests)
- Set comment on column via writer API (single + overwrite)
- COMMENT mixed with INSERT/ALTER in same DuckDB session
- Table + column comments in both orderings
- Multiple custom tags on columns
- Comment on table with data via DuckDB

### `tests/test_settings.py` (7 tests)
- Small data inlined (no Parquet files)
- Large data → Parquet files
- Mixed inlined + Parquet reads
- Inlining disabled → always Parquet
- Custom data paths / data_path override on read/scan

### `tests/test_migration.py` (7 tests)
- v0.3 catalog (no snapshot_changes table): metadata read, empty table read, graceful skip
- v0.4 catalog (with snapshot_changes + partial_max): metadata read, empty table read, table check
- Unsupported version → ValueError
- Missing version → ValueError
- SUPPORTED_DUCKLAKE_VERSIONS constant check

All 24 tests pass.