### PR TITLE
fix: case-insensitive table name lookup

### DIFF
--- a/src/ducklake_core/_catalog.py
+++ b/src/ducklake_core/_catalog.py
@@ -328,7 +328,7 @@ class DuckLakeCatalogReader:
                    s.path, s.path_is_relative
             FROM ducklake_table t
             JOIN ducklake_schema s ON t.schema_id = s.schema_id
-            WHERE t.table_name = ?
+            WHERE LOWER(t.table_name) = LOWER(?)
               AND s.schema_name = ?
               AND ? >= t.begin_snapshot
               AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
@@ -374,7 +374,7 @@ class DuckLakeCatalogReader:
               ON c.table_id = t.table_id
               AND ? >= c.begin_snapshot
               AND (? < c.end_snapshot OR c.end_snapshot IS NULL)
-            WHERE t.table_name = ?
+            WHERE LOWER(t.table_name) = LOWER(?)
               AND s.schema_name = ?
               AND ? >= t.begin_snapshot
               AND (? < t.end_snapshot OR t.end_snapshot IS NULL)

--- a/src/ducklake_core/_writer.py
+++ b/src/ducklake_core/_writer.py
@@ -1059,7 +1059,7 @@ class DuckLakeCatalogWriter:
         row = con.execute(
             "SELECT t.table_id FROM ducklake_table t "
             "JOIN ducklake_schema s ON t.schema_id = s.schema_id "
-            "WHERE t.table_name = ? AND s.schema_name = ? "
+            "WHERE LOWER(t.table_name) = LOWER(?) AND s.schema_name = ? "
             "AND ? >= t.begin_snapshot AND (? < t.end_snapshot OR t.end_snapshot IS NULL) "
             "AND ? >= s.begin_snapshot AND (? < s.end_snapshot OR s.end_snapshot IS NULL)",
             [table_name, schema_name, snapshot_id, snapshot_id, snapshot_id, snapshot_id],
@@ -1383,7 +1383,7 @@ class DuckLakeCatalogWriter:
             "SELECT t.table_id, t.path, t.path_is_relative, s.path, s.path_is_relative "
             "FROM ducklake_table t "
             "JOIN ducklake_schema s ON t.schema_id = s.schema_id "
-            "WHERE t.table_name = ? AND s.schema_name = ? "
+            "WHERE LOWER(t.table_name) = LOWER(?) AND s.schema_name = ? "
             "AND ? >= t.begin_snapshot AND (? < t.end_snapshot OR t.end_snapshot IS NULL) "
             "AND ? >= s.begin_snapshot AND (? < s.end_snapshot OR s.end_snapshot IS NULL)",
             [table_name, schema_name, snapshot_id, snapshot_id, snapshot_id, snapshot_id],

--- a/tests/test_case_insensitive.py
+++ b/tests/test_case_insensitive.py
@@ -1,0 +1,127 @@
+"""Tests for case-insensitive table name lookup."""
+
+from __future__ import annotations
+
+import duckdb
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from ducklake_polars import read_ducklake, write_ducklake
+
+
+class TestCaseInsensitiveTableLookup:
+    """Table names stored by DuckDB are lowercase (unquoted).
+
+    The ducklake reader/writer must find them regardless of the case
+    used in the Python API call.
+    """
+
+    def test_lowercase_created_uppercase_read(self, make_write_catalog):
+        """Create table with lowercase name, read with uppercase."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"x": pl.Series([1, 2, 3], dtype=pl.Int32)})
+
+        # DuckDB stores unquoted names as lowercase
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = f"ducklake:sqlite:{cat.metadata_path}" if cat.backend == "sqlite" else f"ducklake:postgres:{cat.metadata_path}"
+        con.execute(f"ATTACH '{source}' AS ducklake (DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)")
+        con.execute("CREATE TABLE ducklake.main.mytable (x INTEGER)")
+        con.execute("INSERT INTO ducklake.main.mytable VALUES (1), (2), (3)")
+        con.close()
+
+        # Read with uppercase — should work
+        result = read_ducklake(cat.metadata_path, "MYTABLE")
+        assert result.shape[0] == 3
+        assert_frame_equal(result, df)
+
+    def test_mixedcase_created_lowercase_read(self, make_write_catalog):
+        """Create table with MixedCase (unquoted → stored as lowercase), read with lowercase."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"x": pl.Series([10, 20], dtype=pl.Int32)})
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = f"ducklake:sqlite:{cat.metadata_path}" if cat.backend == "sqlite" else f"ducklake:postgres:{cat.metadata_path}"
+        con.execute(f"ATTACH '{source}' AS ducklake (DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)")
+        # Unquoted MixedCase → DuckDB stores as 'mixedtable'
+        con.execute("CREATE TABLE ducklake.main.MixedTable (x INTEGER)")
+        con.execute("INSERT INTO ducklake.main.MixedTable VALUES (10), (20)")
+        con.close()
+
+        # Read with lowercase — should work
+        result = read_ducklake(cat.metadata_path, "mixedtable")
+        assert_frame_equal(result, df)
+
+        # Read with original MixedCase — should also work
+        result2 = read_ducklake(cat.metadata_path, "MixedTable")
+        assert_frame_equal(result2, df)
+
+    def test_mytable_all_case_variants(self, make_write_catalog):
+        """Create 'MyTable', insert data, read with 'mytable' and 'MYTABLE' → same data."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"a": pl.Series([1, 2], dtype=pl.Int32), "b": ["hello", "world"]})
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = f"ducklake:sqlite:{cat.metadata_path}" if cat.backend == "sqlite" else f"ducklake:postgres:{cat.metadata_path}"
+        con.execute(f"ATTACH '{source}' AS ducklake (DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)")
+        # Unquoted MyTable → stored as 'mytable'
+        con.execute("CREATE TABLE ducklake.main.MyTable (a INTEGER, b VARCHAR)")
+        con.execute("INSERT INTO ducklake.main.MyTable VALUES (1, 'hello'), (2, 'world')")
+        con.close()
+
+        result_lower = read_ducklake(cat.metadata_path, "mytable")
+        result_upper = read_ducklake(cat.metadata_path, "MYTABLE")
+        result_mixed = read_ducklake(cat.metadata_path, "MyTable")
+
+        assert_frame_equal(result_lower, df)
+        assert_frame_equal(result_upper, df)
+        assert_frame_equal(result_mixed, df)
+
+    def test_quoted_name_preserves_case(self, make_write_catalog):
+        """Quoted name stays as-is (DuckDB preserves case for quoted identifiers)."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"x": pl.Series([42], dtype=pl.Int32)})
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = f"ducklake:sqlite:{cat.metadata_path}" if cat.backend == "sqlite" else f"ducklake:postgres:{cat.metadata_path}"
+        con.execute(f"ATTACH '{source}' AS ducklake (DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)")
+        # Quoted → DuckDB stores as 'CaseSensitive' (preserves case)
+        con.execute('CREATE TABLE ducklake.main."CaseSensitive" (x INTEGER)')
+        con.execute('INSERT INTO ducklake.main."CaseSensitive" VALUES (42)')
+        con.close()
+
+        # Exact quoted name works
+        result = read_ducklake(cat.metadata_path, "CaseSensitive")
+        assert_frame_equal(result, df)
+
+        # Case-insensitive lookup also works (LOWER match)
+        result2 = read_ducklake(cat.metadata_path, "casesensitive")
+        assert_frame_equal(result2, df)
+
+    def test_write_case_insensitive(self, make_write_catalog):
+        """Writing to a table with different case than stored should work."""
+        cat = make_write_catalog()
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = f"ducklake:sqlite:{cat.metadata_path}" if cat.backend == "sqlite" else f"ducklake:postgres:{cat.metadata_path}"
+        con.execute(f"ATTACH '{source}' AS ducklake (DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)")
+        con.execute("CREATE TABLE ducklake.main.mytable (x INTEGER)")
+        con.close()
+
+        # Write using uppercase name
+        df = pl.DataFrame({"x": pl.Series([100, 200], dtype=pl.Int32)})
+        write_ducklake(df, cat.metadata_path, "MYTABLE", mode="append")
+
+        # Read back
+        result = read_ducklake(cat.metadata_path, "mytable")
+        assert_frame_equal(result, df)


### PR DESCRIPTION
DuckDB stores unquoted table names in lowercase. The ducklake reader/writer previously used exact string matching on table names, so `CREATE TABLE MyTable(...)` would store as "mytable" but a lookup for "MyTable" would fail.

**Fix:** Use `LOWER(t.table_name) = LOWER(?)` instead of `t.table_name = ?` in all table name lookup queries:
- `_catalog.py`: `get_table()` and `get_table_with_columns()`
- `_writer.py`: `_table_exists()` and `_get_table_info()`

**Tests** (`tests/test_case_insensitive.py`):
1. Create table with lowercase name, read with uppercase → works
2. Create table with MixedCase, read with lowercase → works
3. Create "MyTable", insert data, read with "mytable" and "MYTABLE" → same data
4. Quoted name preserves case but case-insensitive lookup still works
5. Write to table using different case than stored → works

All 1002 existing tests continue to pass.