### PR TITLE
feat: add_files support — register existing Parquet files into DuckLake

### DIFF
--- a/src/ducklake_core/_writer.py
+++ b/src/ducklake_core/_writer.py
@@ -4660,6 +4660,160 @@ class DuckLakeCatalogWriter:
 
         self._commit_metadata()
 
+    # ------------------------------------------------------------------
+    # ADD FILES (register existing Parquet files)
+    # ------------------------------------------------------------------
+
+    @_retryable
+    def add_files(
+        self,
+        table_name: str,
+        file_paths: list[str],
+        *,
+        schema_name: str = "main",
+    ) -> int:
+        """Register existing Parquet files into a DuckLake table.
+
+        The files are **not** copied or moved — they are referenced
+        in-place.  Schema validation is performed by reading the first
+        file's schema and comparing against the table's column
+        definitions.
+
+        Parameters
+        ----------
+        table_name
+            Name of the target table.
+        file_paths
+            List of paths to Parquet files (local or object storage).
+        schema_name
+            Schema name (default: ``"main"``).
+
+        Returns
+        -------
+        int
+            The new snapshot ID.
+
+        Raises
+        ------
+        ValueError
+            If the table does not exist, no file paths are given, or
+            the Parquet schema does not match the table schema.
+        """
+        if not file_paths:
+            msg = "file_paths must not be empty"
+            raise ValueError(msg)
+
+        con = self._connect()
+        snapshot_info = self._get_latest_snapshot()
+        if snapshot_info is None:
+            snap_id, schema_ver, next_cat_id, next_file_id = -1, 0, 1, 1
+        else:
+            snap_id, schema_ver, next_cat_id, next_file_id = snapshot_info
+        self._start_write_transaction(snap_id)
+
+        table_id, table_path, table_path_rel, schema_path, schema_path_rel = (
+            self._get_table_info(table_name, schema_name, snap_id)
+        )
+        self._track_table_write(table_id, "insert")
+
+        columns = self._get_columns_for_table(table_id, snap_id)
+
+        # --- Validate schema from the first file ----------------------
+        first_table = storage.read_parquet(file_paths[0])
+        first_schema = first_table.schema
+        file_col_names = set(first_schema.names)
+        catalog_col_names = {c[1] for c in columns}
+        if file_col_names != catalog_col_names:
+            msg = (
+                f"Schema mismatch: file columns {sorted(file_col_names)} "
+                f"do not match table columns {sorted(catalog_col_names)}"
+            )
+            raise ValueError(msg)
+
+        # --- Allocate IDs ---------------------------------------------
+        n_files = len(file_paths)
+        new_next_file_id = next_file_id + n_files
+
+        existing_stats = self._get_table_stats(table_id)
+        row_id_start = existing_stats[1] if existing_stats is not None else 0
+
+        new_snap = self._create_snapshot(schema_ver, next_cat_id, new_next_file_id)
+
+        mapping_id = self._register_name_mapping(table_id, columns)
+
+        total_records = 0
+        total_file_size = 0
+        current_file_id = next_file_id
+        current_row_id = row_id_start
+
+        for fpath in file_paths:
+            df = storage.read_parquet(fpath)
+            record_count = len(df)
+            file_size = storage.get_file_size(fpath)
+            footer_size = _read_parquet_footer_size(fpath)
+
+            # Register the file with an absolute path (path_is_relative=False)
+            self._register_data_file_absolute(
+                current_file_id, table_id, new_snap, fpath,
+                record_count, file_size, footer_size, current_row_id,
+                None, mapping_id,
+            )
+
+            col_stats = self._compute_file_column_stats(df, columns)
+            self._register_file_column_stats(current_file_id, table_id, col_stats)
+            self._update_table_column_stats(table_id, columns, col_stats)
+
+            total_records += record_count
+            total_file_size += file_size
+            current_file_id += 1
+            current_row_id += record_count
+
+        self._update_table_stats(table_id, total_records, total_file_size)
+
+        self._record_change(new_snap, f"inserted_into_table:{table_id}")
+        self._commit_metadata()
+        return new_snap
+
+    def _register_data_file_absolute(
+        self,
+        data_file_id: int,
+        table_id: int,
+        new_snap: int,
+        abs_path: str,
+        record_count: int,
+        file_size: int,
+        footer_size: int,
+        row_id_start: int,
+        partition_id: int | None,
+        mapping_id: int,
+    ) -> None:
+        """Register a data file with an absolute (non-relative) path."""
+        con = self._connect()
+        con.execute(
+            "INSERT INTO ducklake_data_file "
+            "(data_file_id, table_id, begin_snapshot, end_snapshot, file_order, "
+            "path, path_is_relative, file_format, record_count, file_size_bytes, "
+            "footer_size, row_id_start, partition_id, encryption_key, "
+            + ("mapping_id, partial_max) "
+               "VALUES (?, ?, ?, NULL, NULL, ?, ?, 'parquet', ?, ?, ?, ?, ?, NULL, ?, NULL)"
+               if self._is_v04 else
+               "partial_file_info, mapping_id) "
+               "VALUES (?, ?, ?, NULL, NULL, ?, ?, 'parquet', ?, ?, ?, ?, ?, NULL, NULL, ?)"),
+            [
+                data_file_id,
+                table_id,
+                new_snap,
+                abs_path,
+                False,  # path_is_relative = False
+                record_count,
+                file_size,
+                footer_size,
+                row_id_start,
+                partition_id,
+                mapping_id,
+            ],
+        )
+
     @staticmethod
     def _resolve_vacuum_path(
         file_path: str,

--- a/src/ducklake_polars/__init__.py
+++ b/src/ducklake_polars/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "update_ducklake",
     "merge_ducklake",
     "create_table_as_ducklake",
+    "add_files_ducklake",
     "alter_ducklake_add_column",
     "alter_ducklake_drop_column",
     "alter_ducklake_rename_column",
@@ -559,6 +560,72 @@ def create_table_as_ducklake(
         commit_message=commit_message,
     ) as writer:
         writer.create_table_with_data(table, df, schema_name=schema)
+
+
+def add_files_ducklake(
+    path: str | Path,
+    table: str,
+    file_paths: list[str],
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+    max_retries: int = 3,
+    retry_wait_ms: float = 100,
+    retry_backoff: float = 2.0,
+) -> int:
+    """
+    Register existing Parquet files into a DuckLake table.
+
+    The files are **not** copied or moved — they are referenced
+    in-place. Schema validation is performed by reading the first
+    file's schema and comparing against the table's column definitions.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file (.ducklake or .db).
+        Supports SQLite and PostgreSQL backends.
+    table
+        Name of the target table.
+    file_paths
+        List of paths to Parquet files (local or object storage).
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+    author
+        Author name for the snapshot change record.
+    commit_message
+        Commit message for the snapshot change record.
+
+    Returns
+    -------
+    int
+        The new snapshot ID.
+
+    Raises
+    ------
+    ValueError
+        If the table does not exist, no file paths are given, or
+        the Parquet schema does not match the table schema.
+    """
+    from ducklake_polars._writer import DuckLakeCatalogWriter
+
+    metadata_path = os.fspath(path)
+    dp = os.fspath(data_path) if data_path is not None else None
+
+    with DuckLakeCatalogWriter(
+        metadata_path,
+        data_path_override=dp,
+        author=author,
+        commit_message=commit_message,
+        max_retries=max_retries,
+        retry_wait_ms=retry_wait_ms,
+        retry_backoff=retry_backoff,
+    ) as writer:
+        return writer.add_files(table, file_paths, schema_name=schema)
 
 
 def alter_ducklake_add_column(

--- a/src/ducklake_polars/_writer.py
+++ b/src/ducklake_polars/_writer.py
@@ -240,6 +240,21 @@ class DuckLakeCatalogWriter:
         )
 
     # ------------------------------------------------------------------
+    # ADD FILES
+    # ------------------------------------------------------------------
+
+    def add_files(
+        self,
+        table_name: str,
+        file_paths: list[str],
+        *,
+        schema_name: str = "main",
+    ) -> int:
+        return self._core.add_files(
+            table_name, file_paths, schema_name=schema_name,
+        )
+
+    # ------------------------------------------------------------------
     # ALTER TABLE
     # ------------------------------------------------------------------
 

--- a/tests/test_add_files.py
+++ b/tests/test_add_files.py
@@ -1,0 +1,182 @@
+"""Tests for add_files — registering existing Parquet files into DuckLake."""
+
+from __future__ import annotations
+
+import os
+
+import polars as pl
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from polars.testing import assert_frame_equal
+
+from ducklake_polars import (
+    add_files_ducklake,
+    create_ducklake_table,
+    read_ducklake,
+    write_ducklake,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_parquet_file(path: str, df: pl.DataFrame) -> str:
+    """Write a Polars DataFrame to a Parquet file and return its path."""
+    arrow_table = df.to_arrow()
+    pq.write_table(arrow_table, path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddFiles:
+    """Test add_files functionality."""
+
+    def test_add_single_file(self, ducklake_catalog):
+        """Add a single Parquet file to an existing table."""
+        catalog = ducklake_catalog
+        catalog.execute("CREATE TABLE ducklake.t1 (a BIGINT, b VARCHAR)")
+        catalog.close()
+
+        # Write a Parquet file outside the catalog
+        parquet_path = os.path.join(
+            os.path.dirname(catalog.metadata_path)
+            if catalog.backend == "sqlite"
+            else str(ducklake_catalog.data_path),
+            "external_data.parquet",
+        )
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        _write_parquet_file(parquet_path, df)
+
+        # Add the file
+        add_files_ducklake(
+            catalog.metadata_path,
+            "t1",
+            [parquet_path],
+            data_path=catalog.data_path,
+        )
+
+        # Read back and verify
+        result = read_ducklake(
+            catalog.metadata_path, "t1", data_path=catalog.data_path
+        )
+        assert len(result) == 3
+        assert sorted(result["a"].to_list()) == [1, 2, 3]
+
+    def test_add_multiple_files(self, ducklake_catalog):
+        """Add multiple Parquet files to an existing table."""
+        catalog = ducklake_catalog
+        catalog.execute("CREATE TABLE ducklake.t1 (x BIGINT, y DOUBLE)")
+        catalog.close()
+
+        base_dir = os.path.dirname(catalog.metadata_path) if catalog.backend == "sqlite" else catalog.data_path
+
+        # Write two Parquet files
+        df1 = pl.DataFrame({"x": [1, 2], "y": [1.0, 2.0]})
+        df2 = pl.DataFrame({"x": [3, 4], "y": [3.0, 4.0]})
+        path1 = _write_parquet_file(os.path.join(base_dir, "part1.parquet"), df1)
+        path2 = _write_parquet_file(os.path.join(base_dir, "part2.parquet"), df2)
+
+        add_files_ducklake(
+            catalog.metadata_path,
+            "t1",
+            [path1, path2],
+            data_path=catalog.data_path,
+        )
+
+        result = read_ducklake(
+            catalog.metadata_path, "t1", data_path=catalog.data_path
+        )
+        assert len(result) == 4
+        assert sorted(result["x"].to_list()) == [1, 2, 3, 4]
+
+    def test_read_after_add_files(self, ducklake_catalog):
+        """Data is visible after adding files."""
+        catalog = ducklake_catalog
+        catalog.execute("CREATE TABLE ducklake.t1 (id BIGINT, name VARCHAR)")
+        catalog.close()
+
+        base_dir = os.path.dirname(catalog.metadata_path) if catalog.backend == "sqlite" else catalog.data_path
+
+        df = pl.DataFrame({"id": [10, 20, 30], "name": ["alice", "bob", "carol"]})
+        parquet_path = _write_parquet_file(
+            os.path.join(base_dir, "people.parquet"), df
+        )
+
+        add_files_ducklake(
+            catalog.metadata_path,
+            "t1",
+            [parquet_path],
+            data_path=catalog.data_path,
+        )
+
+        result = read_ducklake(
+            catalog.metadata_path, "t1", data_path=catalog.data_path
+        )
+        expected = df.sort("id")
+        actual = result.sort("id")
+        assert_frame_equal(actual, expected)
+
+    def test_schema_mismatch_raises_error(self, ducklake_catalog):
+        """Adding a file with mismatched schema raises ValueError."""
+        catalog = ducklake_catalog
+        catalog.execute("CREATE TABLE ducklake.t1 (a BIGINT, b VARCHAR)")
+        catalog.close()
+
+        base_dir = os.path.dirname(catalog.metadata_path) if catalog.backend == "sqlite" else catalog.data_path
+
+        # Parquet file with different columns
+        df_bad = pl.DataFrame({"a": [1], "c": [2]})
+        bad_path = _write_parquet_file(
+            os.path.join(base_dir, "bad.parquet"), df_bad
+        )
+
+        with pytest.raises(ValueError, match="Schema mismatch"):
+            add_files_ducklake(
+                catalog.metadata_path,
+                "t1",
+                [bad_path],
+                data_path=catalog.data_path,
+            )
+
+    def test_add_files_then_insert(self, ducklake_catalog):
+        """Adding files then inserting more data — both visible."""
+        catalog = ducklake_catalog
+        catalog.execute("CREATE TABLE ducklake.t1 (v BIGINT)")
+        catalog.close()
+
+        base_dir = os.path.dirname(catalog.metadata_path) if catalog.backend == "sqlite" else catalog.data_path
+
+        # Add a parquet file
+        df_file = pl.DataFrame({"v": [100, 200]})
+        parquet_path = _write_parquet_file(
+            os.path.join(base_dir, "added.parquet"), df_file
+        )
+        add_files_ducklake(
+            catalog.metadata_path,
+            "t1",
+            [parquet_path],
+            data_path=catalog.data_path,
+        )
+
+        # Insert more data via write_ducklake
+        df_insert = pl.DataFrame({"v": [300, 400]})
+        write_ducklake(
+            df_insert,
+            catalog.metadata_path,
+            "t1",
+            mode="append",
+            data_path=catalog.data_path,
+        )
+
+        result = read_ducklake(
+            catalog.metadata_path, "t1", data_path=catalog.data_path
+        )
+        assert len(result) == 4
+        assert sorted(result["v"].to_list()) == [100, 200, 300, 400]


### PR DESCRIPTION
## Summary

Add the ability to register existing Parquet files into a DuckLake catalog without copying or moving them. This closes a feature gap from TEST_PARITY.md.

## Changes

### Core writer (`src/ducklake_core/_writer.py`)
- `add_files(table_name, file_paths)` method:
  - Validates schema by reading the first file and comparing column names against the table definition
  - Registers each file in `ducklake_data_file` with absolute paths (`path_is_relative=False`)
  - Computes per-file column statistics (null count, min/max) and registers them
  - Updates aggregate table stats and table column stats
  - Creates a new snapshot with proper change tracking
- `_register_data_file_absolute()` helper for non-relative path entries

### Polars wrapper (`src/ducklake_polars/_writer.py`)
- Thin delegation to core writer's `add_files()`

### Public API (`src/ducklake_polars/__init__.py`)
- `add_files_ducklake(path, table, file_paths, ...)` function with full parameter set (schema, data_path, author, commit_message, retry config)

### Tests (`tests/test_add_files.py`)
5 test cases, all passing:
1. Add a single Parquet file to an existing table
2. Add multiple Parquet files
3. Read table after adding files — data is visible
4. Schema mismatch raises `ValueError`
5. Add files then insert more data — both visible