### PR TITLE
fix: make schema name lookup case-insensitive

### DIFF
--- a/src/ducklake_core/_catalog.py
+++ b/src/ducklake_core/_catalog.py
@@ -329,7 +329,7 @@ class DuckLakeCatalogReader:
             FROM ducklake_table t
             JOIN ducklake_schema s ON t.schema_id = s.schema_id
             WHERE LOWER(t.table_name) = LOWER(?)
-              AND s.schema_name = ?
+              AND LOWER(s.schema_name) = LOWER(?)
               AND ? >= t.begin_snapshot
               AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
               AND ? >= s.begin_snapshot
@@ -375,7 +375,7 @@ class DuckLakeCatalogReader:
               AND ? >= c.begin_snapshot
               AND (? < c.end_snapshot OR c.end_snapshot IS NULL)
             WHERE LOWER(t.table_name) = LOWER(?)
-              AND s.schema_name = ?
+              AND LOWER(s.schema_name) = LOWER(?)
               AND ? >= t.begin_snapshot
               AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
               AND ? >= s.begin_snapshot

--- a/src/ducklake_core/_writer.py
+++ b/src/ducklake_core/_writer.py
@@ -1038,7 +1038,7 @@ class DuckLakeCatalogWriter:
         con = self._connect()
         row = con.execute(
             "SELECT schema_id, path, path_is_relative FROM ducklake_schema "
-            "WHERE schema_name = ? AND begin_snapshot <= ? "
+            "WHERE LOWER(schema_name) = LOWER(?) AND begin_snapshot <= ? "
             "AND (end_snapshot IS NULL OR end_snapshot > ?)",
             [schema_name, snapshot_id, snapshot_id],
         ).fetchone()
@@ -1059,7 +1059,7 @@ class DuckLakeCatalogWriter:
         row = con.execute(
             "SELECT t.table_id FROM ducklake_table t "
             "JOIN ducklake_schema s ON t.schema_id = s.schema_id "
-            "WHERE LOWER(t.table_name) = LOWER(?) AND s.schema_name = ? "
+            "WHERE LOWER(t.table_name) = LOWER(?) AND LOWER(s.schema_name) = LOWER(?) "
             "AND ? >= t.begin_snapshot AND (? < t.end_snapshot OR t.end_snapshot IS NULL) "
             "AND ? >= s.begin_snapshot AND (? < s.end_snapshot OR s.end_snapshot IS NULL)",
             [table_name, schema_name, snapshot_id, snapshot_id, snapshot_id, snapshot_id],
@@ -1383,7 +1383,7 @@ class DuckLakeCatalogWriter:
             "SELECT t.table_id, t.path, t.path_is_relative, s.path, s.path_is_relative "
             "FROM ducklake_table t "
             "JOIN ducklake_schema s ON t.schema_id = s.schema_id "
-            "WHERE LOWER(t.table_name) = LOWER(?) AND s.schema_name = ? "
+            "WHERE LOWER(t.table_name) = LOWER(?) AND LOWER(s.schema_name) = LOWER(?) "
             "AND ? >= t.begin_snapshot AND (? < t.end_snapshot OR t.end_snapshot IS NULL) "
             "AND ? >= s.begin_snapshot AND (? < s.end_snapshot OR s.end_snapshot IS NULL)",
             [table_name, schema_name, snapshot_id, snapshot_id, snapshot_id, snapshot_id],
@@ -3542,7 +3542,7 @@ class DuckLakeCatalogWriter:
         con = self._connect()
         row = con.execute(
             "SELECT schema_id FROM ducklake_schema "
-            "WHERE schema_name = ? AND begin_snapshot <= ? "
+            "WHERE LOWER(schema_name) = LOWER(?) AND begin_snapshot <= ? "
             "AND (end_snapshot IS NULL OR end_snapshot > ?)",
             [schema_name, snapshot_id, snapshot_id],
         ).fetchone()
@@ -4767,7 +4767,7 @@ class DuckLakeCatalogWriter:
             row = con.execute(
                 "SELECT v.view_id FROM ducklake_view v "
                 "JOIN ducklake_schema s ON v.schema_id = s.schema_id "
-                "WHERE v.view_name = ? AND s.schema_name = ? "
+                "WHERE v.view_name = ? AND LOWER(s.schema_name) = LOWER(?) "
                 "AND ? >= v.begin_snapshot AND (? < v.end_snapshot OR v.end_snapshot IS NULL) "
                 "AND ? >= s.begin_snapshot AND (? < s.end_snapshot OR s.end_snapshot IS NULL)",
                 [view_name, schema_name, snapshot_id, snapshot_id, snapshot_id, snapshot_id],

--- a/tests/test_schema_case.py
+++ b/tests/test_schema_case.py
@@ -1,0 +1,180 @@
+"""Tests for case-insensitive schema name lookup."""
+
+from __future__ import annotations
+
+import duckdb
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from ducklake_polars import (
+    create_ducklake_schema,
+    read_ducklake,
+    write_ducklake,
+)
+
+
+class TestSchemaCaseInsensitive:
+    """Schema names stored by DuckDB are lowercase (unquoted).
+
+    The ducklake reader/writer must find them regardless of the case
+    used in the Python API call.
+    """
+
+    def test_create_schema_mixed_case_read_lowercase(self, make_write_catalog):
+        """Create schema 'MySchema' via DuckDB (stored as 'myschema'), read with lowercase."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"x": pl.Series([1, 2, 3], dtype=pl.Int32)})
+
+        # DuckDB stores unquoted schema names as lowercase
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = (
+            f"ducklake:sqlite:{cat.metadata_path}"
+            if cat.backend == "sqlite"
+            else f"ducklake:postgres:{cat.metadata_path}"
+        )
+        con.execute(
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE SCHEMA ducklake.MySchema")
+        con.execute("CREATE TABLE ducklake.MySchema.test_tbl (x INTEGER)")
+        con.execute("INSERT INTO ducklake.MySchema.test_tbl VALUES (1), (2), (3)")
+        con.close()
+
+        # Read with lowercase schema — should work
+        result = read_ducklake(cat.metadata_path, "test_tbl", schema="myschema")
+        assert_frame_equal(result, df)
+
+    def test_create_schema_mixed_case_read_uppercase(self, make_write_catalog):
+        """Create schema 'MySchema' via DuckDB (stored as 'myschema'), read with MixedCase."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"x": pl.Series([10, 20], dtype=pl.Int32)})
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = (
+            f"ducklake:sqlite:{cat.metadata_path}"
+            if cat.backend == "sqlite"
+            else f"ducklake:postgres:{cat.metadata_path}"
+        )
+        con.execute(
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE SCHEMA ducklake.MySchema")
+        con.execute("CREATE TABLE ducklake.MySchema.test_tbl (x INTEGER)")
+        con.execute("INSERT INTO ducklake.MySchema.test_tbl VALUES (10), (20)")
+        con.close()
+
+        # Read with MixedCase schema — should work
+        result = read_ducklake(cat.metadata_path, "test_tbl", schema="MySchema")
+        assert_frame_equal(result, df)
+
+        # Read with UPPERCASE schema — should also work
+        result2 = read_ducklake(cat.metadata_path, "test_tbl", schema="MYSCHEMA")
+        assert_frame_equal(result2, df)
+
+    def test_write_to_schema_case_insensitive(self, make_write_catalog):
+        """Create schema via API with lowercase, write using MixedCase."""
+        cat = make_write_catalog()
+
+        create_ducklake_schema(cat.metadata_path, "myschema")
+
+        df = pl.DataFrame({"a": pl.Series([1, 2], dtype=pl.Int64)})
+
+        # Write using MixedCase schema name
+        write_ducklake(df, cat.metadata_path, "tbl", schema="MySchema", mode="error")
+
+        # Read back with lowercase
+        result = read_ducklake(cat.metadata_path, "tbl", schema="myschema")
+        assert_frame_equal(result, df)
+
+        # Read back with UPPERCASE
+        result2 = read_ducklake(cat.metadata_path, "tbl", schema="MYSCHEMA")
+        assert_frame_equal(result2, df)
+
+    def test_default_schema_no_regression(self, make_write_catalog):
+        """Create table in default 'main' schema — no regression."""
+        cat = make_write_catalog()
+        df = pl.DataFrame({"v": pl.Series([100, 200], dtype=pl.Int64)})
+
+        write_ducklake(df, cat.metadata_path, "default_tbl", mode="error")
+
+        result = read_ducklake(cat.metadata_path, "default_tbl")
+        assert_frame_equal(result, df)
+
+        # Also read with explicit "main"
+        result2 = read_ducklake(cat.metadata_path, "default_tbl", schema="main")
+        assert_frame_equal(result2, df)
+
+        # And with "MAIN"
+        result3 = read_ducklake(cat.metadata_path, "default_tbl", schema="MAIN")
+        assert_frame_equal(result3, df)
+
+    def test_multiple_schemas_mixed_case(self, make_write_catalog):
+        """Multiple schemas created with mixed case — each resolves correctly."""
+        cat = make_write_catalog()
+
+        con = duckdb.connect()
+        con.install_extension("ducklake")
+        con.load_extension("ducklake")
+        source = (
+            f"ducklake:sqlite:{cat.metadata_path}"
+            if cat.backend == "sqlite"
+            else f"ducklake:postgres:{cat.metadata_path}"
+        )
+        con.execute(
+            f"ATTACH '{source}' AS ducklake "
+            f"(DATA_PATH '{cat.data_path}', DATA_INLINING_ROW_LIMIT 0)"
+        )
+        con.execute("CREATE SCHEMA ducklake.alpha")
+        con.execute("CREATE TABLE ducklake.alpha.tbl (x INTEGER)")
+        con.execute("INSERT INTO ducklake.alpha.tbl VALUES (1)")
+
+        con.execute("CREATE SCHEMA ducklake.beta")
+        con.execute("CREATE TABLE ducklake.beta.tbl (x INTEGER)")
+        con.execute("INSERT INTO ducklake.beta.tbl VALUES (2)")
+        con.close()
+
+        # Read with various cases
+        r1 = read_ducklake(cat.metadata_path, "tbl", schema="Alpha")
+        assert r1["x"].to_list() == [1]
+
+        r2 = read_ducklake(cat.metadata_path, "tbl", schema="BETA")
+        assert r2["x"].to_list() == [2]
+
+        r3 = read_ducklake(cat.metadata_path, "tbl", schema="alpha")
+        assert r3["x"].to_list() == [1]
+
+        r4 = read_ducklake(cat.metadata_path, "tbl", schema="beta")
+        assert r4["x"].to_list() == [2]
+
+    def test_create_schema_duplicate_case_insensitive(self, make_write_catalog):
+        """Creating a schema with a different case than an existing one should raise."""
+        cat = make_write_catalog()
+
+        create_ducklake_schema(cat.metadata_path, "myschema")
+
+        # Creating with different case should detect the duplicate
+        with pytest.raises(ValueError, match="already exists"):
+            create_ducklake_schema(cat.metadata_path, "MYSCHEMA")
+
+    def test_append_to_schema_case_insensitive(self, make_write_catalog):
+        """Write to a schema with one case, then append with another."""
+        cat = make_write_catalog()
+
+        create_ducklake_schema(cat.metadata_path, "analytics")
+
+        df1 = pl.DataFrame({"val": pl.Series([1], dtype=pl.Int64)})
+        write_ducklake(df1, cat.metadata_path, "data", schema="analytics", mode="error")
+
+        df2 = pl.DataFrame({"val": pl.Series([2], dtype=pl.Int64)})
+        write_ducklake(df2, cat.metadata_path, "data", schema="ANALYTICS", mode="append")
+
+        result = read_ducklake(cat.metadata_path, "data", schema="Analytics")
+        assert result.shape[0] == 2
+        assert sorted(result["val"].to_list()) == [1, 2]


### PR DESCRIPTION
## Problem

DuckDB stores unquoted schema names as lowercase. However, ducklake-polars was performing case-sensitive comparisons for schema name lookups in SQL queries. This caused failures when:

- A schema was created with mixed case via DuckDB (e.g., `CREATE SCHEMA MySchema` → stored as `myschema`)
- The user then tried to read/write tables in that schema using the original casing (e.g., `schema='MySchema'`)

## Fix

Apply `LOWER()` to all `schema_name` comparisons in SQL queries, matching the existing pattern already used for table names (`LOWER(t.table_name) = LOWER(?)`).

### Files changed:

**`src/ducklake_core/_catalog.py`** (2 queries):
- `get_table()`: `s.schema_name = ?` → `LOWER(s.schema_name) = LOWER(?)`
- `get_table_with_columns()`: same fix

**`src/ducklake_core/_writer.py`** (5 queries):
- `_resolve_schema_info()`: `schema_name = ?` → `LOWER(schema_name) = LOWER(?)`
- `_table_exists()`: `s.schema_name = ?` → `LOWER(s.schema_name) = LOWER(?)`
- Table path resolution query: same fix
- `_schema_exists()`: same fix
- View lookup query: same fix

## Tests

New test file `tests/test_schema_case.py` with 7 tests:
- Create schema with MixedCase via DuckDB, read with lowercase
- Create schema with MixedCase via DuckDB, read with uppercase/MixedCase
- Write to schema using different case than creation
- Default schema (`main`/`MAIN`) no regression
- Multiple schemas with mixed case lookups
- Duplicate schema detection across cases
- Append with different case than initial write

All existing tests pass (test_basic, test_case_insensitive, test_write_ddl).