### PR TITLE
Add custom exception hierarchy for better error handling

### DIFF
--- a/src/ducklake_core/__init__.py
+++ b/src/ducklake_core/__init__.py
@@ -1,5 +1,9 @@
 """ducklake-core: Arrow-based internals for DuckLake catalog access."""
 
 from ducklake_core._catalog_api import DuckLakeCatalog as DuckLakeCatalog
+from ducklake_core._exceptions import CatalogVersionError as CatalogVersionError
+from ducklake_core._exceptions import DuckLakeError as DuckLakeError
+from ducklake_core._exceptions import SchemaNotFoundError as SchemaNotFoundError
+from ducklake_core._exceptions import TableNotFoundError as TableNotFoundError
 from ducklake_core._writer import DuckLakeCatalogWriter as DuckLakeCatalogWriter
 from ducklake_core._writer import TransactionConflictError as TransactionConflictError

--- a/src/ducklake_core/_catalog.py
+++ b/src/ducklake_core/_catalog.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import ducklake_core._storage as storage
 from ducklake_core._backend import create_backend
+from ducklake_core._exceptions import CatalogVersionError, SchemaNotFoundError, TableNotFoundError
 
 import pyarrow as pa
 
@@ -185,13 +186,13 @@ class DuckLakeCatalogReader:
         version = meta.get("version")
         if version is None:
             msg = "No version found in ducklake_metadata — is this a valid DuckLake catalog?"
-            raise ValueError(msg)
+            raise CatalogVersionError(msg)
         if version not in SUPPORTED_DUCKLAKE_VERSIONS:
             msg = (
                 f"Unsupported DuckLake catalog version '{version}'. "
                 f"Supported versions: {', '.join(sorted(SUPPORTED_DUCKLAKE_VERSIONS))}"
             )
-            raise ValueError(msg)
+            raise CatalogVersionError(msg)
         self._catalog_version = version
         if self._data_path_override is None and "data_path" in meta:
             self._data_path = meta["data_path"]
@@ -339,7 +340,7 @@ class DuckLakeCatalogReader:
         ).fetchone()
         if row is None:
             msg = f"Table '{schema_name}.{table_name}' not found at snapshot {snapshot_id}"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         return TableInfo(
             table_id=row[0],
             table_name=row[1],
@@ -391,7 +392,7 @@ class DuckLakeCatalogReader:
         ).fetchall()
         if not rows:
             msg = f"Table '{schema_name}.{table_name}' not found at snapshot {snapshot_id}"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
 
         # Extract table info from the first row
         r0 = rows[0]

--- a/src/ducklake_core/_exceptions.py
+++ b/src/ducklake_core/_exceptions.py
@@ -1,0 +1,22 @@
+"""Custom exception hierarchy for DuckLake.
+
+All specific exceptions inherit from both :class:`DuckLakeError` and
+``ValueError`` so that existing ``except ValueError`` handlers continue
+to work while new code can catch the precise error type.
+"""
+
+
+class DuckLakeError(Exception):
+    """Base exception for all DuckLake errors."""
+
+
+class TableNotFoundError(DuckLakeError, ValueError):
+    """Raised when a requested table does not exist in the catalog."""
+
+
+class SchemaNotFoundError(DuckLakeError, ValueError):
+    """Raised when a requested schema does not exist in the catalog."""
+
+
+class CatalogVersionError(DuckLakeError, ValueError):
+    """Raised when the catalog version is unsupported or missing."""

--- a/src/ducklake_core/_writer.py
+++ b/src/ducklake_core/_writer.py
@@ -26,6 +26,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import ducklake_core._storage as storage
 from ducklake_core._backend import PostgreSQLBackend, SQLiteBackend, create_backend
+from ducklake_core._exceptions import SchemaNotFoundError, TableNotFoundError
 from ducklake_core._schema import arrow_type_to_duckdb, duckdb_type_to_arrow
 
 
@@ -1044,7 +1045,7 @@ class DuckLakeCatalogWriter:
         ).fetchone()
         if row is None:
             msg = f"Schema '{schema_name}' not found at snapshot {snapshot_id}"
-            raise ValueError(msg)
+            raise SchemaNotFoundError(msg)
         return (row[0], row[1] or "", bool(row[2]) if row[2] is not None else True)
 
     # ------------------------------------------------------------------
@@ -1390,7 +1391,7 @@ class DuckLakeCatalogWriter:
         ).fetchone()
         if row is None:
             msg = f"Table '{schema_name}.{table_name}' not found at snapshot {snapshot_id}"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         return (
             row[0],
             row[1] or "",
@@ -3237,7 +3238,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         columns = self._get_columns_for_table(table_id, snap_id)
@@ -3305,7 +3306,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         columns = self._get_columns_for_table(table_id, snap_id)
@@ -3407,7 +3408,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         columns = self._get_columns_for_table(table_id, snap_id)
@@ -3507,7 +3508,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "drop_table")
 
         new_schema_ver = schema_ver + 1
@@ -3626,7 +3627,7 @@ class DuckLakeCatalogWriter:
         schema_id = self._schema_exists(schema_name, snap_id)
         if schema_id is None:
             msg = f"Schema '{schema_name}' not found"
-            raise ValueError(msg)
+            raise SchemaNotFoundError(msg)
 
         tables = self._get_tables_in_schema(schema_id, snap_id)
 
@@ -3696,7 +3697,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(old_table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{old_table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         if self._table_exists(new_table_name, schema_name, snap_id) is not None:
@@ -3785,7 +3786,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         columns = self._get_columns_for_table(table_id, snap_id)
@@ -3874,7 +3875,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         columns = self._get_columns_for_table(table_id, snap_id)
@@ -4059,7 +4060,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         columns = self._get_columns_for_table(table_id, snap_id)
@@ -4149,7 +4150,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
         self._track_table_write(table_id, "ddl")
 
         # Check if there are active sort keys
@@ -4518,7 +4519,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
 
         new_snap = self._create_snapshot(schema_ver, next_cat_id, next_file_id)
 
@@ -4562,7 +4563,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
 
         # Check that the tag exists
         row = con.execute(
@@ -4609,7 +4610,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
 
         columns = self._get_columns_for_table(table_id, snap_id)
         col_id = None
@@ -4666,7 +4667,7 @@ class DuckLakeCatalogWriter:
         table_id = self._table_exists(table_name, schema_name, snap_id)
         if table_id is None:
             msg = f"Table '{schema_name}.{table_name}' not found"
-            raise ValueError(msg)
+            raise TableNotFoundError(msg)
 
         columns = self._get_columns_for_table(table_id, snap_id)
         col_id = None

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,214 @@
+"""Tests for custom DuckLake error hierarchy and user-facing messages."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from ducklake_core import (
+    CatalogVersionError,
+    DuckLakeError,
+    SchemaNotFoundError,
+    TableNotFoundError,
+)
+from ducklake_core._catalog import DuckLakeCatalogReader
+from ducklake_core._writer import DuckLakeCatalogWriter
+from ducklake_polars import read_ducklake
+
+
+# ------------------------------------------------------------------
+# Exception hierarchy
+# ------------------------------------------------------------------
+
+
+class TestExceptionHierarchy:
+    """Verify exception class relationships."""
+
+    def test_base_exception(self):
+        assert issubclass(DuckLakeError, Exception)
+
+    def test_table_not_found_is_ducklake_error(self):
+        assert issubclass(TableNotFoundError, DuckLakeError)
+
+    def test_schema_not_found_is_ducklake_error(self):
+        assert issubclass(SchemaNotFoundError, DuckLakeError)
+
+    def test_catalog_version_error_is_ducklake_error(self):
+        assert issubclass(CatalogVersionError, DuckLakeError)
+
+    def test_catch_all_ducklake_errors(self):
+        """All specific errors are catchable via DuckLakeError."""
+        for exc_cls in (TableNotFoundError, SchemaNotFoundError, CatalogVersionError):
+            with pytest.raises(DuckLakeError):
+                raise exc_cls("test")
+
+
+# ------------------------------------------------------------------
+# TableNotFoundError
+# ------------------------------------------------------------------
+
+
+class TestTableNotFoundError:
+    """Reading a non-existent table should raise TableNotFoundError."""
+
+    def test_read_nonexistent_table(self, ducklake_catalog):
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.real_table (x INTEGER)")
+        cat.execute("INSERT INTO ducklake.real_table VALUES (1)")
+        cat.close()
+
+        with pytest.raises(TableNotFoundError, match="ghost_table"):
+            read_ducklake(cat.metadata_path, "ghost_table")
+
+    def test_catalog_reader_get_table(self, ducklake_catalog):
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.t (a INTEGER)")
+        cat.close()
+
+        with DuckLakeCatalogReader(cat.metadata_path) as reader:
+            snap = reader.get_current_snapshot()
+            with pytest.raises(TableNotFoundError, match="no_such_table"):
+                reader.get_table("no_such_table", "main", snap.snapshot_id)
+
+    def test_writer_table_not_found(self, ducklake_catalog):
+        """Writer operations on missing tables should raise TableNotFoundError."""
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.t (a INTEGER)")
+        cat.close()
+
+        writer = DuckLakeCatalogWriter(cat.metadata_path, data_path_override=cat.data_path)
+        with pytest.raises(TableNotFoundError, match="missing_table"):
+            writer.insert_data(
+                pa.table({"a": [1]}),
+                "missing_table",
+                schema_name="main",
+            )
+        writer.close()
+
+    def test_error_message_is_helpful(self, ducklake_catalog):
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.t (a INTEGER)")
+        cat.close()
+
+        with DuckLakeCatalogReader(cat.metadata_path) as reader:
+            snap = reader.get_current_snapshot()
+            try:
+                reader.get_table("nope", "main", snap.snapshot_id)
+            except TableNotFoundError as e:
+                msg = str(e)
+                assert "nope" in msg
+                assert "main" in msg
+                assert "snapshot" in msg.lower() or str(snap.snapshot_id) in msg
+
+
+# ------------------------------------------------------------------
+# SchemaNotFoundError
+# ------------------------------------------------------------------
+
+
+class TestSchemaNotFoundError:
+    """Reading from a non-existent schema should raise SchemaNotFoundError."""
+
+    def test_writer_resolve_schema_not_found(self, ducklake_catalog):
+        """_resolve_schema_info raises SchemaNotFoundError for missing schemas."""
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.t (a INTEGER)")
+        cat.close()
+
+        writer = DuckLakeCatalogWriter(cat.metadata_path, data_path_override=cat.data_path)
+        with pytest.raises(SchemaNotFoundError, match="fake_schema"):
+            writer.create_table(
+                "new_table",
+                pa.schema([pa.field("a", pa.int32())]),
+                schema_name="fake_schema",
+            )
+        writer.close()
+
+    def test_insert_bad_schema_raises_ducklake_error(self, ducklake_catalog):
+        """insert_data with bad schema raises a DuckLakeError (table+schema joined lookup)."""
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.t (a INTEGER)")
+        cat.close()
+
+        writer = DuckLakeCatalogWriter(cat.metadata_path, data_path_override=cat.data_path)
+        with pytest.raises(DuckLakeError, match="fake_schema"):
+            writer.insert_data(
+                pa.table({"a": [1]}),
+                "t",
+                schema_name="fake_schema",
+            )
+        writer.close()
+
+
+# ------------------------------------------------------------------
+# CatalogVersionError
+# ------------------------------------------------------------------
+
+
+class TestCatalogVersionError:
+    """Unsupported catalog versions should raise CatalogVersionError."""
+
+    def test_unsupported_version(self, tmp_path):
+        db_path = str(tmp_path / "bad.ducklake")
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "CREATE TABLE ducklake_metadata (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        con.execute(
+            "INSERT INTO ducklake_metadata VALUES ('version', '99.0')"
+        )
+        con.commit()
+        con.close()
+
+        with pytest.raises(CatalogVersionError, match="99.0"):
+            with DuckLakeCatalogReader(db_path) as reader:
+                reader.get_current_snapshot()
+
+    def test_missing_version(self, tmp_path):
+        db_path = str(tmp_path / "empty.ducklake")
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "CREATE TABLE ducklake_metadata (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        con.commit()
+        con.close()
+
+        with pytest.raises(CatalogVersionError, match="No version found"):
+            with DuckLakeCatalogReader(db_path) as reader:
+                reader.get_current_snapshot()
+
+
+# ------------------------------------------------------------------
+# Invalid connection / misc
+# ------------------------------------------------------------------
+
+
+class TestInvalidConnection:
+    """Invalid connection strings should raise appropriate errors."""
+
+    def test_nonexistent_file(self, tmp_path):
+        bad_path = str(tmp_path / "does_not_exist.ducklake")
+        # Opening a non-existent SQLite file will create an empty DB,
+        # which will fail on metadata query
+        with pytest.raises(Exception):
+            with DuckLakeCatalogReader(bad_path) as reader:
+                reader.get_current_snapshot()
+
+    def test_write_to_nonexistent_table(self, ducklake_catalog):
+        """Writing to a table that doesn't exist should fail clearly."""
+        cat = ducklake_catalog
+        cat.execute("CREATE TABLE ducklake.existing (a INTEGER)")
+        cat.close()
+
+        writer = DuckLakeCatalogWriter(cat.metadata_path, data_path_override=cat.data_path)
+        with pytest.raises((TableNotFoundError, SchemaNotFoundError, DuckLakeError)):
+            writer.insert_data(
+                pa.table({"a": [1]}),
+                "nonexistent",
+                schema_name="main",
+            )
+        writer.close()


### PR DESCRIPTION
## Summary

Introduces a structured exception hierarchy for DuckLake errors, replacing generic `ValueError`/`RuntimeError` raises with specific, catchable exception types.

## Changes

### New exception classes (`src/ducklake_core/_exceptions.py`)
- **`DuckLakeError`** — base exception for all DuckLake errors
- **`TableNotFoundError(DuckLakeError, ValueError)`** — raised when a table doesn't exist
- **`SchemaNotFoundError(DuckLakeError, ValueError)`** — raised when a schema doesn't exist
- **`CatalogVersionError(DuckLakeError, ValueError)`** — raised for unsupported/missing catalog versions

All specific exceptions also inherit from `ValueError` for **backward compatibility** — existing `except ValueError` handlers continue to work.

### Updated modules
- **`_catalog.py`** — `get_table`, `get_table_with_columns`, `_load_metadata` now raise specific exceptions
- **`_writer.py`** — 14 `_get_table_info`/`_resolve_schema_info` call sites updated (table and schema not-found errors)
- **`__init__.py`** — exports all new exception classes

### Tests (`tests/test_error_handling.py`)
- Exception hierarchy validation
- `TableNotFoundError` from reader, writer, and `read_ducklake`
- `SchemaNotFoundError` from writer's `create_table` and `insert_data`
- `CatalogVersionError` for unsupported and missing versions
- Invalid connection string handling
- Helpful error message assertions

All existing tests pass unchanged (backward compatible).