### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,822 @@
+# API Reference
+
+## ducklake_polars
+
+### Read Operations
+
+#### `scan_ducklake`
+
+```python
+scan_ducklake(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    snapshot_version: int | None = None,
+    snapshot_time: datetime | str | None = None,
+    data_path: str | Path | None = None,
+) -> pl.LazyFrame
+```
+
+Lazily read a DuckLake table as a Polars LazyFrame. Predicates, projections, and file pruning are pushed down through Polars' native optimizer.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `path` | `str \| Path` | required | Path to catalog file (`.ducklake` or `.db`), or a PostgreSQL connection string |
+| `table` | `str` | required | Name of the table to read |
+| `schema` | `str` | `"main"` | Schema name |
+| `snapshot_version` | `int \| None` | `None` | Read at a specific snapshot version |
+| `snapshot_time` | `datetime \| str \| None` | `None` | Read at a specific timestamp (datetime or ISO string) |
+| `data_path` | `str \| Path \| None` | `None` | Override the data path stored in the catalog |
+
+**Returns:** `pl.LazyFrame`
+
+**Raises:** `ValueError` if both `snapshot_version` and `snapshot_time` are specified.
+
+---
+
+#### `read_ducklake` (Polars)
+
+```python
+read_ducklake(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    columns: list[str] | None = None,
+    snapshot_version: int | None = None,
+    snapshot_time: datetime | str | None = None,
+    data_path: str | Path | None = None,
+) -> pl.DataFrame
+```
+
+Eagerly read a DuckLake table into a Polars DataFrame. Convenience wrapper around `scan_ducklake(...).collect()`.
+
+**Additional parameter:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `columns` | `list[str] \| None` | `None` | Columns to select. If `None`, reads all columns |
+
+---
+
+### Write Operations
+
+#### `write_ducklake` (Polars)
+
+```python
+write_ducklake(
+    df: pl.DataFrame,
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    mode: str = "error",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
+    max_retries: int = 3,
+    retry_wait_ms: float = 100,
+    retry_backoff: float = 2.0,
+) -> None
+```
+
+Write a Polars DataFrame to a DuckLake table.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `df` | `pl.DataFrame` | required | DataFrame to write |
+| `path` | `str \| Path` | required | Path to catalog file |
+| `table` | `str` | required | Table name |
+| `schema` | `str` | `"main"` | Schema name |
+| `mode` | `str` | `"error"` | Write mode: `"error"`, `"append"`, or `"overwrite"` |
+| `data_path` | `str \| Path \| None` | `None` | Override data path |
+| `data_inlining_row_limit` | `int` | `0` | Max rows to store inline in the catalog (0 = disabled) |
+| `author` | `str \| None` | `None` | Author name for the snapshot |
+| `commit_message` | `str \| None` | `None` | Commit message for the snapshot |
+| `max_retries` | `int` | `3` | Max transaction retries on conflict |
+| `retry_wait_ms` | `float` | `100` | Initial wait between retries (ms) |
+| `retry_backoff` | `float` | `2.0` | Backoff multiplier for retries |
+
+---
+
+#### `create_table_as_ducklake` (Polars)
+
+```python
+create_table_as_ducklake(
+    df: pl.DataFrame,
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Create a new table and insert data in a single atomic snapshot. Equivalent to `CREATE TABLE ... AS SELECT ...`.
+
+---
+
+#### `delete_ducklake` (Polars)
+
+```python
+delete_ducklake(
+    path: str | Path,
+    table: str,
+    predicate: pl.Expr,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> int
+```
+
+Delete rows matching a predicate from a DuckLake table. Creates Iceberg-compatible position-delete files.
+
+**Returns:** `int` — number of rows deleted.
+
+---
+
+#### `update_ducklake` (Polars)
+
+```python
+update_ducklake(
+    path: str | Path,
+    table: str,
+    updates: dict[str, object],
+    predicate: pl.Expr,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> int
+```
+
+Update rows matching a predicate. Atomically deletes old rows and inserts new rows with updated values in a single snapshot.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `updates` | `dict[str, object]` | Column names → new values. Values can be literals or `pl.Expr` |
+| `predicate` | `pl.Expr` | Boolean expression. Rows where `True` are updated |
+
+**Returns:** `int` — number of rows updated.
+
+---
+
+#### `merge_ducklake` (Polars)
+
+```python
+merge_ducklake(
+    path: str | Path,
+    table: str,
+    source_df: pl.DataFrame,
+    on: str | list[str],
+    *,
+    when_matched_update: dict[str, object] | bool | None = None,
+    when_not_matched_insert: bool = True,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> tuple[int, int]
+```
+
+Merge a source DataFrame into an existing DuckLake table (upsert). Implemented as delete + insert in a single snapshot.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `on` | `str \| list[str]` | required | Column(s) to match on |
+| `when_matched_update` | `dict \| bool \| None` | `None` | `None` = leave matched rows; `True` = replace; `dict` = update specific columns |
+| `when_not_matched_insert` | `bool` | `True` | Insert unmatched source rows |
+
+**Returns:** `tuple[int, int]` — `(rows_updated, rows_inserted)`.
+
+---
+
+#### `add_files_ducklake`
+
+```python
+add_files_ducklake(
+    path: str | Path,
+    table: str,
+    file_paths: list[str],
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+    max_retries: int = 3,
+    retry_wait_ms: float = 100,
+    retry_backoff: float = 2.0,
+) -> int
+```
+
+Register existing Parquet files into a DuckLake table. Files are referenced in-place (not copied). Schema is validated against the table.
+
+**Returns:** `int` — the new snapshot ID.
+
+---
+
+### DDL Operations
+
+#### `create_ducklake_table` (Polars)
+
+```python
+create_ducklake_table(
+    path: str | Path,
+    table: str,
+    polars_schema: pl.Schema | dict[str, pl.DataType],
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Create a new empty table using a Polars schema.
+
+---
+
+#### `drop_ducklake_table`
+
+```python
+drop_ducklake_table(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `rename_ducklake_table`
+
+```python
+rename_ducklake_table(
+    path: str | Path,
+    old_table: str,
+    new_table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `alter_ducklake_add_column` (Polars)
+
+```python
+alter_ducklake_add_column(
+    path: str | Path,
+    table: str,
+    col_name: str,
+    dtype: pl.DataType,
+    *,
+    default: object = None,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Add a column to a table. Existing rows get `NULL` (or the specified `default`).
+
+---
+
+#### `alter_ducklake_drop_column`
+
+```python
+alter_ducklake_drop_column(
+    path: str | Path,
+    table: str,
+    col_name: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `alter_ducklake_rename_column`
+
+```python
+alter_ducklake_rename_column(
+    path: str | Path,
+    table: str,
+    old_col_name: str,
+    new_col_name: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Rename a column. Old Parquet files with the old column name are reconciled transparently via column history.
+
+---
+
+#### `alter_ducklake_set_type`
+
+```python
+alter_ducklake_set_type(
+    path: str | Path,
+    table: str,
+    column_name: str,
+    new_type: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Change a column's type using a DuckDB type string (e.g., `"BIGINT"`, `"VARCHAR"`, `"DOUBLE"`). Existing Parquet files keep their original types; the reader casts on the fly.
+
+---
+
+#### `alter_ducklake_set_partitioned_by`
+
+```python
+alter_ducklake_set_partitioned_by(
+    path: str | Path,
+    table: str,
+    columns: list[str],
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Set identity-transform partitioning. Future inserts write one Parquet file per unique combination of partition column values (Hive-style layout).
+
+---
+
+#### `alter_ducklake_set_sort_keys`
+
+```python
+alter_ducklake_set_sort_keys(
+    path: str | Path,
+    table: str,
+    sort_keys: list[str | tuple[str, str] | tuple[str, str, str]],
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Set sort keys on a table. Each element can be:
+
+- `"col"` — ascending, nulls last
+- `("col", "DESC")` — descending, nulls last
+- `("col", "ASC", "NULLS_FIRST")` — ascending, nulls first
+
+---
+
+#### `alter_ducklake_reset_sort_keys`
+
+```python
+alter_ducklake_reset_sort_keys(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Remove sort keys from a table.
+
+---
+
+#### `create_ducklake_schema`
+
+```python
+create_ducklake_schema(
+    path: str | Path,
+    schema_name: str,
+    *,
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `drop_ducklake_schema`
+
+```python
+drop_ducklake_schema(
+    path: str | Path,
+    schema_name: str,
+    *,
+    cascade: bool = False,
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Drop a schema. Pass `cascade=True` to drop all tables in the schema first.
+
+---
+
+#### `create_ducklake_view`
+
+```python
+create_ducklake_view(
+    path: str | Path,
+    view_name: str,
+    sql: str,
+    *,
+    schema: str = "main",
+    or_replace: bool = False,
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `drop_ducklake_view`
+
+```python
+drop_ducklake_view(
+    path: str | Path,
+    view_name: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+### Tags
+
+#### `set_ducklake_table_tag`
+
+```python
+set_ducklake_table_tag(
+    path: str | Path,
+    table: str,
+    key: str,
+    value: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+Set a key-value tag on a table. The `"comment"` key is interoperable with DuckDB's `COMMENT ON TABLE`.
+
+---
+
+#### `set_ducklake_column_tag`
+
+```python
+set_ducklake_column_tag(
+    path: str | Path,
+    table: str,
+    column: str,
+    key: str,
+    value: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `delete_ducklake_table_tag`
+
+```python
+delete_ducklake_table_tag(
+    path: str | Path,
+    table: str,
+    key: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+#### `delete_ducklake_column_tag`
+
+```python
+delete_ducklake_column_tag(
+    path: str | Path,
+    table: str,
+    column: str,
+    key: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+---
+
+### Maintenance
+
+#### `expire_snapshots`
+
+```python
+expire_snapshots(
+    path: str | Path,
+    *,
+    older_than_snapshot: int | None = None,
+    keep_last_n: int | None = None,
+    data_path: str | Path | None = None,
+) -> int
+```
+
+Expire old snapshots and clean up associated metadata. This is a metadata-only operation — call `vacuum_ducklake` afterwards to delete orphaned Parquet files.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `older_than_snapshot` | `int \| None` | Expire snapshots with `snapshot_id < older_than_snapshot` |
+| `keep_last_n` | `int \| None` | Keep the most recent *n* snapshots, expire the rest |
+
+**Returns:** `int` — number of snapshots expired.
+
+---
+
+#### `vacuum_ducklake`
+
+```python
+vacuum_ducklake(
+    path: str | Path,
+    *,
+    data_path: str | Path | None = None,
+) -> int
+```
+
+Delete orphaned Parquet files not referenced by any catalog entry. Run `expire_snapshots` first.
+
+**Returns:** `int` — number of Parquet files deleted.
+
+---
+
+#### `rewrite_data_files_ducklake`
+
+```python
+rewrite_data_files_ducklake(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    data_path: str | Path | None = None,
+    author: str | None = None,
+    commit_message: str | None = None,
+    max_retries: int = 3,
+    retry_wait_ms: float = 100,
+    retry_backoff: float = 2.0,
+) -> int
+```
+
+Rewrite data files for compaction — merge small files and remove deleted rows. Reads all active data files, writes consolidated Parquet files, and updates the catalog atomically.
+
+**Returns:** `int` — the new snapshot ID, or `-1` if no rewrite was needed.
+
+---
+
+### Catalog Inspection
+
+#### `DuckLakeCatalog` (Polars)
+
+```python
+from ducklake_polars import DuckLakeCatalog
+
+catalog = DuckLakeCatalog(path: str | Path, *, data_path: str | Path | None = None)
+```
+
+High-level interface for inspecting DuckLake catalog metadata. All methods return `pl.DataFrame` (except `current_snapshot()` which returns `int`).
+
+| Method | Returns | Description |
+|---|---|---|
+| `snapshots()` | DataFrame with `snapshot_id`, `snapshot_time`, `schema_version` | All snapshots |
+| `current_snapshot()` | `int` | Latest snapshot ID |
+| `table_info(schema=)` | DataFrame with `table_name`, `table_id`, `file_count`, `file_size_bytes`, `delete_file_count`, `delete_row_count` | Per-table storage stats |
+| `list_files(table, schema=, snapshot_version=)` | DataFrame with `data_file`, `data_file_size_bytes`, `delete_file`, `delete_row_count` | Files for a table |
+| `list_schemas(snapshot_version=)` | DataFrame with `schema_id`, `schema_name` | All schemas |
+| `list_tables(schema=, snapshot_version=)` | DataFrame with `table_id`, `table_name` | Tables in a schema |
+| `options()` | DataFrame with `key`, `value` | Catalog key-value metadata |
+| `settings()` | DataFrame with `catalog_type`, `data_path` | Backend type and data path |
+| `table_tags(table, schema=)` | DataFrame with `key`, `value` | Table-level tags |
+| `column_tags(table, column, schema=)` | DataFrame with `key`, `value` | Column-level tags |
+| `sort_keys(table, schema=)` | DataFrame | Active sort keys with direction and null ordering |
+| `table_insertions(table, start_version, end_version, schema=)` | DataFrame with `snapshot_id` + table columns | Rows inserted between snapshots |
+| `table_deletions(table, start_version, end_version, schema=)` | DataFrame with `snapshot_id` + table columns | Rows deleted between snapshots |
+| `table_changes(table, start_version, end_version, schema=)` | DataFrame with `snapshot_id`, `change_type` + table columns | Full change data feed |
+
+The `change_type` column in `table_changes` can be: `"insert"`, `"delete"`, `"update_preimage"`, `"update_postimage"`.
+
+---
+
+## ducklake_pandas
+
+The Pandas API mirrors the Polars API with these key differences:
+
+### Differences from Polars
+
+| Feature | Polars | Pandas |
+|---|---|---|
+| Lazy evaluation | `scan_ducklake()` returns `LazyFrame` | Not available |
+| Read predicates | Pushdown via Polars optimizer | `predicate=` callable on `read_ducklake()` |
+| DML predicates | `pl.Expr` (e.g., `pl.col("id") == 2`) | Callable `(df -> Series[bool])` or `True`/`False` |
+| Update values | Literal or `pl.Expr` | Literal or callable `(df -> Series)` |
+| Table creation schema | `pl.Schema` or `dict[str, pl.DataType]` | `dict[str, str]` of DuckDB type strings |
+| Return types | `pl.DataFrame` | `pd.DataFrame` |
+
+### `read_ducklake` (Pandas)
+
+```python
+from ducklake_pandas import read_ducklake
+
+read_ducklake(
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    columns: list[str] | None = None,
+    predicate: Callable[[pd.DataFrame], pd.Series] | None = None,
+    snapshot_version: int | None = None,
+    snapshot_time: datetime | str | None = None,
+    data_path: str | Path | None = None,
+) -> pd.DataFrame
+```
+
+The `predicate` parameter accepts a callable for partition pruning and stats-based file pruning:
+
+```python
+df = read_ducklake("catalog.ducklake", "users", predicate=lambda df: df["region"] == "US")
+```
+
+### `write_ducklake` (Pandas)
+
+```python
+from ducklake_pandas import write_ducklake
+
+write_ducklake(
+    df: pd.DataFrame,
+    path: str | Path,
+    table: str,
+    *,
+    schema: str = "main",
+    mode: str = "error",
+    data_path: str | Path | None = None,
+    data_inlining_row_limit: int = 0,
+    author: str | None = None,
+    commit_message: str | None = None,
+) -> None
+```
+
+### `delete_ducklake` (Pandas)
+
+```python
+from ducklake_pandas import delete_ducklake
+
+delete_ducklake(
+    path: str | Path,
+    table: str,
+    predicate: Callable[[pd.DataFrame], pd.Series] | bool,
+    *,
+    schema: str = "main",
+    ...
+) -> int
+```
+
+Predicate is a callable or `True` (delete all rows) / `False` (delete nothing):
+
+```python
+deleted = delete_ducklake("catalog.ducklake", "users", lambda df: df["id"] == 2)
+```
+
+### `update_ducklake` (Pandas)
+
+```python
+from ducklake_pandas import update_ducklake
+
+update_ducklake(
+    path: str | Path,
+    table: str,
+    updates: dict[str, Any],
+    predicate: Callable[[pd.DataFrame], pd.Series],
+    *,
+    schema: str = "main",
+    ...
+) -> int
+```
+
+Update values can be literals or callables:
+
+```python
+updated = update_ducklake(
+    "catalog.ducklake", "users",
+    updates={"region": "APAC"},
+    predicate=lambda df: df["name"] == "Eve",
+)
+```
+
+### `create_ducklake_table` (Pandas)
+
+```python
+from ducklake_pandas import create_ducklake_table
+
+create_ducklake_table(
+    path: str | Path,
+    table: str,
+    schema_dict: dict[str, str],
+    *,
+    schema: str = "main",
+    ...
+) -> None
+```
+
+Uses DuckDB type strings instead of Polars types:
+
+```python
+create_ducklake_table("catalog.ducklake", "events", {"ts": "timestamp", "value": "double"})
+```
+
+### `DuckLakeCatalog` (Pandas)
+
+```python
+from ducklake_pandas import DuckLakeCatalog
+
+catalog = DuckLakeCatalog("catalog.ducklake")
+catalog.snapshots()  # returns pd.DataFrame
+```
+
+All methods have identical signatures to the Polars version but return `pd.DataFrame` instead of `pl.DataFrame`.
+
+### Shared API
+
+All other functions (DDL, tags, views, maintenance, merge) share the same signatures as the Polars versions. Import from `ducklake_pandas` instead of `ducklake_polars`.
+
+---
+
+## `TransactionConflictError`
+
+```python
+from ducklake_polars import TransactionConflictError
+# or
+from ducklake_pandas import TransactionConflictError
+```
+
+Raised when a write operation detects a concurrent modification conflict. See [Concurrency](concurrency.md) for details.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,151 @@
+# Catalog Backends
+
+ducklake-dataframe supports three catalog backends for storing DuckLake metadata. The backend is determined by the `path` parameter passed to any API function.
+
+## SQLite (default)
+
+SQLite is the default backend — it uses Python's built-in `sqlite3` module, so there are zero extra dependencies.
+
+```python
+from ducklake_polars import write_ducklake, scan_ducklake
+
+# Any file path ending in .ducklake or .db uses SQLite
+write_ducklake(df, "catalog.ducklake", "users", mode="error")
+lf = scan_ducklake("catalog.ducklake", "users")
+```
+
+### File format
+
+DuckLake catalog files (`.ducklake`) are standard SQLite databases. You can inspect them with any SQLite tool:
+
+```bash
+sqlite3 catalog.ducklake ".tables"
+# ducklake_column_stats      ducklake_data_file         ducklake_metadata
+# ducklake_column_tag        ducklake_delete_file       ducklake_partition
+# ...
+```
+
+### When to use SQLite
+
+- **Single-user workflows** — local analysis, notebooks, scripts
+- **Zero-dependency setups** — no external database to manage
+- **Development and testing** — catalogs are just files, easy to copy/delete
+- **DuckDB interop** — DuckDB's native DuckLake extension reads the same SQLite files
+
+## PostgreSQL
+
+PostgreSQL provides a shared, network-accessible catalog backend suitable for team environments.
+
+### Installation
+
+```bash
+pip install ducklake-dataframe[polars,postgres]
+# or
+pip install ducklake-dataframe[pandas,postgres]
+```
+
+This installs `psycopg2` as the PostgreSQL driver.
+
+### Usage
+
+Pass a PostgreSQL connection string as the `path` parameter:
+
+```python
+from ducklake_polars import write_ducklake, scan_ducklake
+
+PG_DSN = "postgresql://user:password@localhost:5432/mydb"
+
+write_ducklake(df, PG_DSN, "users", mode="error")
+lf = scan_ducklake(PG_DSN, "users")
+```
+
+The connection string format follows the standard PostgreSQL URI syntax:
+
+```
+postgresql://[user[:password]@][host][:port][/dbname][?param=value]
+```
+
+### Schema setup
+
+DuckLake tables are automatically created in the PostgreSQL database when you first write data. The DuckLake metadata tables (`ducklake_snapshot`, `ducklake_table`, etc.) live alongside your regular PostgreSQL tables.
+
+### When to use PostgreSQL
+
+- **Multi-user environments** — shared catalogs across a team
+- **Concurrent access** — PostgreSQL handles locking and transactions
+- **Production pipelines** — durable, backed up, monitored
+- **Existing infrastructure** — if you already run PostgreSQL
+
+### Running tests with PostgreSQL
+
+```bash
+DUCKLAKE_PG_DSN="postgresql://user:pass@localhost/testdb" pytest
+```
+
+## DuckDB
+
+DuckDB `.ducklake` files are SQLite-format, so they are read via the SQLite backend. There is no separate DuckDB backend — the same `sqlite3` module reads catalogs created by DuckDB's native DuckLake extension.
+
+### Installation
+
+```bash
+pip install ducklake-dataframe[polars,duckdb]
+```
+
+The `duckdb` extra is only needed if you want to use DuckDB directly (e.g., for creating catalogs with `ATTACH 'ducklake:...'`). ducklake-dataframe itself reads DuckDB-created catalogs via `sqlite3`.
+
+### Interoperability
+
+Catalogs are fully interoperable between DuckDB and ducklake-dataframe:
+
+```python
+import duckdb
+
+# Create with DuckDB
+con = duckdb.connect()
+con.execute("INSTALL ducklake; LOAD ducklake")
+con.execute("ATTACH 'ducklake:sqlite:catalog.ducklake' AS lake (DATA_PATH 'data/')")
+con.execute("CREATE TABLE lake.events (ts TIMESTAMP, value DOUBLE)")
+con.execute("INSERT INTO lake.events VALUES ('2025-01-01', 42.0)")
+con.close()
+
+# Read with ducklake-dataframe
+from ducklake_polars import scan_ducklake
+lf = scan_ducklake("catalog.ducklake", "events")
+print(lf.collect())
+```
+
+And vice versa — create with ducklake-dataframe, query with DuckDB SQL.
+
+### Catalog format versions
+
+Both DuckLake catalog format **v0.3** and **v0.4** are supported. The format version is detected automatically from the catalog metadata.
+
+## Backend comparison
+
+| Feature | SQLite | PostgreSQL | DuckDB |
+|---|---|---|---|
+| Dependencies | None (stdlib) | `psycopg2` | `sqlite3` (stdlib) |
+| Shared access | Single process | Multi-user | Single process |
+| Network access | Local file only | TCP/IP | Local file only |
+| Setup | Zero config | Database server | Zero config |
+| DuckDB interop | ✅ | ✅ | ✅ |
+| Catalog format | v0.3, v0.4 | v0.3, v0.4 | v0.3, v0.4 |
+
+## Data path override
+
+All backends support the `data_path` parameter to override where Parquet data files are stored or read from:
+
+```python
+# Catalog metadata in SQLite, data files in a different directory
+write_ducklake(df, "catalog.ducklake", "users", mode="error", data_path="/data/warehouse/")
+
+# Read with explicit data path
+lf = scan_ducklake("catalog.ducklake", "users", data_path="/data/warehouse/")
+```
+
+This is useful when:
+
+- The catalog has been moved to a different location
+- Data files are on a different filesystem or mount point
+- You want to separate metadata from data storage

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,0 +1,155 @@
+# Concurrency
+
+ducklake-dataframe provides transaction retry and conflict detection for concurrent write scenarios. This page covers how writes are serialized, how conflicts are detected, and how to configure retry behavior.
+
+## Write model
+
+All write operations in ducklake-dataframe are **snapshot-based**:
+
+1. Read the current snapshot (latest catalog state)
+2. Perform the operation (compute new/deleted rows, DDL changes)
+3. Write new Parquet files (if applicable)
+4. Commit a new snapshot to the catalog
+
+Each snapshot is an atomic unit — either the entire operation succeeds or nothing changes. The catalog backend (SQLite or PostgreSQL) provides the serialization guarantees.
+
+## TransactionConflictError
+
+When two writers try to commit simultaneously and a conflict is detected, a `TransactionConflictError` is raised:
+
+```python
+from ducklake_polars import TransactionConflictError, write_ducklake
+# or
+from ducklake_pandas import TransactionConflictError
+
+try:
+    write_ducklake(df, "catalog.ducklake", "users", mode="append")
+except TransactionConflictError as e:
+    print(f"Conflict detected: {e}")
+    # Retry, queue, or handle
+```
+
+This exception is importable from both `ducklake_polars` and `ducklake_pandas`.
+
+## Automatic retries
+
+Write operations that support retries will automatically retry on conflict with exponential backoff. The following parameters control retry behavior:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `max_retries` | `3` | Maximum number of retry attempts |
+| `retry_wait_ms` | `100` | Initial wait time between retries (milliseconds) |
+| `retry_backoff` | `2.0` | Multiplier for wait time on each subsequent retry |
+
+### Functions with retry support
+
+- `write_ducklake()` — insert, append, overwrite
+- `add_files_ducklake()` — register external Parquet files
+- `rewrite_data_files_ducklake()` — compaction
+
+### Example
+
+```python
+write_ducklake(
+    df,
+    "catalog.ducklake",
+    "users",
+    mode="append",
+    max_retries=5,          # Try up to 5 times
+    retry_wait_ms=200,      # Start with 200ms wait
+    retry_backoff=2.0,      # Double the wait each retry: 200ms, 400ms, 800ms, 1600ms
+)
+```
+
+With these settings, the retry sequence would be:
+1. First attempt
+2. Wait 200ms → retry
+3. Wait 400ms → retry
+4. Wait 800ms → retry
+5. Wait 1600ms → retry
+6. Raise `TransactionConflictError` if still failing
+
+## Backend-specific behavior
+
+### SQLite
+
+SQLite uses file-level locking. Concurrent writes from the same process are serialized by Python's GIL and SQLite's internal locking. Concurrent writes from different processes use SQLite's filesystem locking — one writer proceeds while others wait or get a "database is locked" error.
+
+For single-writer scenarios (the most common case), SQLite works without issues.
+
+### PostgreSQL
+
+PostgreSQL provides row-level locking and MVCC (Multi-Version Concurrency Control). Concurrent writes from multiple clients are handled by PostgreSQL's transaction isolation:
+
+- Snapshot reads are consistent within a transaction
+- Conflicting writes are detected at commit time
+- The retry mechanism re-reads the latest snapshot before each attempt
+
+PostgreSQL is the recommended backend for multi-user or multi-process write scenarios.
+
+## Patterns
+
+### Single writer (recommended for SQLite)
+
+The simplest and most reliable pattern — one process writes at a time:
+
+```python
+# Worker process
+write_ducklake(df, "catalog.ducklake", "users", mode="append")
+```
+
+### Multiple writers with retries (PostgreSQL)
+
+For concurrent pipelines, use PostgreSQL with retries:
+
+```python
+PG_DSN = "postgresql://user:pass@host/db"
+
+# Worker 1
+write_ducklake(df1, PG_DSN, "users", mode="append", max_retries=5)
+
+# Worker 2 (concurrent)
+write_ducklake(df2, PG_DSN, "users", mode="append", max_retries=5)
+```
+
+### Explicit conflict handling
+
+Catch conflicts and implement custom logic:
+
+```python
+from ducklake_polars import TransactionConflictError, write_ducklake
+
+def write_with_fallback(df, path, table):
+    try:
+        write_ducklake(df, path, table, mode="append", max_retries=3)
+    except TransactionConflictError:
+        # Log, queue for later, alert, etc.
+        print(f"Failed to write to {table} after retries")
+        raise
+```
+
+## Author and commit metadata
+
+All write operations support `author` and `commit_message` parameters for auditing concurrent modifications:
+
+```python
+write_ducklake(
+    df,
+    "catalog.ducklake",
+    "users",
+    mode="append",
+    author="pipeline-worker-1",
+    commit_message="Daily ETL load for 2025-06-15",
+)
+```
+
+These are stored in the snapshot metadata and can be inspected via the catalog API.
+
+## Known limitations
+
+- **No optimistic concurrency control** — ducklake-dataframe does not implement full OCC with conflict resolution. The retry mechanism re-reads and re-applies the entire operation.
+- **No merge conflict resolution** — if two writers modify the same rows, the last writer wins (after retry). There is no automatic three-way merge.
+- **SQLite concurrent writes** — SQLite's file-level locking means only one writer can proceed at a time. For true concurrent writes, use PostgreSQL.
+- **No distributed locking** — there is no external lock manager. Coordination relies entirely on the catalog backend's native transaction support.
+
+For production workloads requiring concurrent writes, PostgreSQL is strongly recommended as the catalog backend.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,221 @@
+# ducklake-dataframe
+
+Pure-Python [Polars](https://pola.rs/) and [Pandas](https://pandas.pydata.org/) integration for [DuckLake](https://ducklake.select/) catalogs — read and write, no DuckDB runtime required.
+
+ducklake-dataframe reads and writes DuckLake metadata directly from SQLite, PostgreSQL, or DuckDB catalog files and scans the underlying Parquet data files through Polars' native Parquet reader or PyArrow. With Polars you get lazy evaluation, predicate pushdown, projection pushdown, file pruning, and all other Polars optimizations out of the box. With Pandas you get familiar DataFrame ergonomics with partition and statistics-based file pruning.
+
+> **Note:** This project is a proof of concept, 100% written by [Claude Code](https://docs.anthropic.com/en/docs/build-with-claude/claude-code/overview). It is not intended for production use.
+
+## Architecture
+
+```
+┌─────────────────┐  ┌─────────────────┐
+│  ducklake_polars │  │  ducklake_pandas │   ← Thin wrappers (API + reader)
+└────────┬────────┘  └────────┬────────┘
+         │                    │
+         └────────┬───────────┘
+                  │
+         ┌────────▼────────┐
+         │   ducklake_core  │   ← Shared engine (catalog, writer, schema, backend)
+         └─────────────────┘
+```
+
+- **`ducklake_core`** — All catalog I/O, write operations, schema mapping, and backend adapters. Uses PyArrow as the internal data representation.
+- **`ducklake_polars`** — Polars-specific reader (lazy `scan_parquet` via `PythonDatasetProvider`), plus a thin API that converts between Polars types and Arrow.
+- **`ducklake_pandas`** — Pandas-specific reader (eager via PyArrow → Pandas conversion), plus a thin API that converts between Pandas types and Arrow.
+
+## Installation
+
+```bash
+# Polars engine
+pip install ducklake-dataframe[polars]
+
+# Pandas engine
+pip install ducklake-dataframe[pandas]
+
+# Both engines
+pip install ducklake-dataframe[polars,pandas]
+
+# With PostgreSQL catalog backend
+pip install ducklake-dataframe[polars,postgres]
+
+# With S3 object storage
+pip install ducklake-dataframe[polars,s3]
+
+# Everything
+pip install ducklake-dataframe[all]
+```
+
+**Core dependency:** `pyarrow >= 10.0` only. Everything else is optional:
+
+| Extra | What it adds |
+|---|---|
+| `polars` | `polars >= 1.0` — Polars engine with lazy evaluation |
+| `pandas` | `pandas >= 1.5` — Pandas engine |
+| `postgres` | `psycopg2` — PostgreSQL catalog backend |
+| `duckdb` | `duckdb` — DuckDB catalog backend |
+| `s3` | `s3fs` — S3 object storage |
+| `gcs` | `gcsfs` — Google Cloud Storage |
+| `azure` | `adlfs` — Azure Blob Storage |
+
+## Quick Start
+
+### Create a catalog and write data
+
+```python
+import polars as pl
+from ducklake_polars import write_ducklake
+
+# Create a new table (mode="error" fails if it already exists)
+df = pl.DataFrame({
+    "id": [1, 2, 3],
+    "name": ["Alice", "Bob", "Carol"],
+    "region": ["US", "EU", "US"],
+})
+write_ducklake(df, "catalog.ducklake", "users", mode="error")
+
+# Append more rows
+more = pl.DataFrame({"id": [4, 5], "name": ["Dave", "Eve"], "region": ["EU", "US"]})
+write_ducklake(more, "catalog.ducklake", "users", mode="append")
+```
+
+### Query with lazy evaluation
+
+```python
+from ducklake_polars import scan_ducklake
+
+# Lazy scan — predicates and projections are pushed down
+lf = scan_ducklake("catalog.ducklake", "users")
+result = (
+    lf.filter(pl.col("region") == "US")
+      .select("id", "name")
+      .collect()
+)
+print(result)
+# shape: (3, 2)
+# ┌─────┬───────┐
+# │ id  ┆ name  │
+# │ --- ┆ ---   │
+# │ i64 ┆ str   │
+# ╞═════╪═══════╡
+# │ 1   ┆ Alice │
+# │ 3   ┆ Carol │
+# │ 5   ┆ Eve   │
+# └─────┴───────┘
+```
+
+### Delete, update, merge
+
+```python
+from ducklake_polars import delete_ducklake, update_ducklake, merge_ducklake
+
+# Delete rows matching a predicate
+deleted = delete_ducklake("catalog.ducklake", "users", pl.col("id") == 2)
+
+# Update rows
+updated = update_ducklake(
+    "catalog.ducklake", "users",
+    updates={"region": "APAC"},
+    predicate=pl.col("name") == "Eve",
+)
+
+# Merge (upsert) — atomic delete + insert in one snapshot
+source = pl.DataFrame({"id": [1, 6], "name": ["Alice2", "Frank"], "region": ["US", "EU"]})
+rows_updated, rows_inserted = merge_ducklake(
+    "catalog.ducklake", "users", source, on="id",
+    when_matched_update=True,
+    when_not_matched_insert=True,
+)
+```
+
+### Time travel
+
+```python
+from ducklake_polars import read_ducklake
+
+# Read at a specific snapshot version
+df_v1 = read_ducklake("catalog.ducklake", "users", snapshot_version=1)
+
+# Read at a specific timestamp
+df_ts = read_ducklake("catalog.ducklake", "users", snapshot_time="2025-06-15T10:30:00")
+```
+
+### Inspect the catalog
+
+```python
+from ducklake_polars import DuckLakeCatalog
+
+catalog = DuckLakeCatalog("catalog.ducklake")
+
+catalog.snapshots()           # All snapshots
+catalog.current_snapshot()    # Latest snapshot ID
+catalog.table_info()          # Per-table file/size stats
+catalog.list_files("users")   # Data + delete files
+catalog.list_schemas()        # All schemas
+catalog.list_tables()         # Tables in default schema
+```
+
+### DuckDB interoperability
+
+Catalogs are fully interoperable — create with DuckDB, read with ducklake-dataframe, or vice versa:
+
+```python
+import duckdb
+
+# DuckDB writes data
+con = duckdb.connect()
+con.execute("INSTALL ducklake; LOAD ducklake")
+con.execute("ATTACH 'ducklake:sqlite:catalog.ducklake' AS lake (DATA_PATH 'data/')")
+con.execute("CREATE TABLE lake.events (ts TIMESTAMP, value DOUBLE)")
+con.execute("INSERT INTO lake.events VALUES ('2025-01-01', 42.0)")
+con.close()
+
+# Polars reads it — no DuckDB needed at runtime
+from ducklake_polars import scan_ducklake
+lf = scan_ducklake("catalog.ducklake", "events")
+print(lf.collect())
+```
+
+## Features
+
+### Read path
+
+- **Lazy and eager reads** — `scan_ducklake()` (Polars LazyFrame) / `read_ducklake()` (eager)
+- **Predicate and projection pushdown** — through Polars' native optimizer; Pandas supports `columns=` and `predicate=`
+- **File pruning** — column-level min/max statistics and partition values
+- **Time travel** — by snapshot version or timestamp
+- **Delete file handling** — Iceberg-compatible positional deletes (cumulative delete files supported)
+- **Schema evolution** — ADD/DROP/RENAME COLUMN handled transparently across file versions
+- **Inlined data** — small tables stored directly in catalog metadata, read transparently
+
+### Write path
+
+- **INSERT** — append, overwrite, or error-on-exists modes
+- **DELETE** — predicate-based row deletion with Iceberg position-delete files
+- **UPDATE** — atomic delete + insert in a single snapshot
+- **MERGE** — upsert with configurable matched/unmatched behavior
+- **CREATE TABLE AS** — single-snapshot table creation with data
+- **Data inlining** — small inserts stored in catalog metadata (configurable threshold)
+- **Partitioned writes** — Hive-style directory layout per partition key
+- **Sort keys** — data sorted before writing for better row group statistics
+- **Author/commit metadata** — `author=` and `commit_message=` on all write operations
+
+### DDL
+
+- **CREATE/DROP TABLE** with full snapshot versioning
+- **ADD/DROP/RENAME COLUMN** with schema evolution tracking
+- **SET TYPE** — column type changes tracked in schema history
+- **CREATE/DROP SCHEMA** with cascade support
+- **RENAME TABLE** preserving table identity
+- **SET/RESET PARTITIONED BY** — identity-transform partitioning
+- **SET/RESET SORTED BY** — with `ASC`/`DESC` and `NULLS_FIRST`/`NULLS_LAST`
+- **CREATE/DROP VIEW** with `OR REPLACE` support
+- **Tags** — key-value metadata on tables and columns
+
+### Catalog backends
+
+- **SQLite** — Python stdlib `sqlite3` (zero dependency)
+- **DuckDB** — `.ducklake` files are SQLite-format, read via `sqlite3`
+- **PostgreSQL** — via `psycopg2` (optional `[postgres]` extra)
+
+Both DuckLake catalog format **v0.3** and **v0.4** are supported.

--- a/docs/object-storage.md
+++ b/docs/object-storage.md
@@ -1,0 +1,178 @@
+# Object Storage
+
+ducklake-dataframe supports reading and writing Parquet data files on cloud object storage via [fsspec](https://filesystem-spec.readthedocs.io/)-compatible backends. The catalog metadata itself remains in SQLite or PostgreSQL — only the data files live on object storage.
+
+## Supported providers
+
+| Provider | Extra | Package |
+|---|---|---|
+| Amazon S3 | `[s3]` | `s3fs` |
+| Google Cloud Storage | `[gcs]` | `gcsfs` |
+| Azure Blob Storage | `[azure]` | `adlfs` |
+
+## Installation
+
+```bash
+# S3
+pip install ducklake-dataframe[polars,s3]
+
+# Google Cloud Storage
+pip install ducklake-dataframe[polars,gcs]
+
+# Azure Blob Storage
+pip install ducklake-dataframe[polars,azure]
+
+# All storage backends
+pip install ducklake-dataframe[all]
+```
+
+## S3
+
+### Setup
+
+```python
+from ducklake_polars import write_ducklake, scan_ducklake
+
+# Write with S3 data path
+write_ducklake(
+    df,
+    "catalog.ducklake",
+    "users",
+    mode="error",
+    data_path="s3://my-bucket/warehouse/",
+)
+
+# Read back
+lf = scan_ducklake(
+    "catalog.ducklake",
+    "users",
+    data_path="s3://my-bucket/warehouse/",
+)
+```
+
+### Authentication
+
+`s3fs` uses standard AWS credential resolution:
+
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+- AWS credentials file (`~/.aws/credentials`)
+- IAM roles (when running on EC2/ECS/Lambda)
+- SSO profiles
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+### S3-compatible stores
+
+`s3fs` works with any S3-compatible API (MinIO, Ceph, R2, etc.) via the `endpoint_url` environment variable:
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:9000
+export AWS_ACCESS_KEY_ID=minioadmin
+export AWS_SECRET_ACCESS_KEY=minioadmin
+```
+
+## Google Cloud Storage
+
+### Setup
+
+```python
+write_ducklake(
+    df,
+    "catalog.ducklake",
+    "users",
+    mode="error",
+    data_path="gs://my-bucket/warehouse/",
+)
+
+lf = scan_ducklake(
+    "catalog.ducklake",
+    "users",
+    data_path="gs://my-bucket/warehouse/",
+)
+```
+
+### Authentication
+
+`gcsfs` uses standard Google Cloud credential resolution:
+
+- Application Default Credentials (`gcloud auth application-default login`)
+- Service account key file (`GOOGLE_APPLICATION_CREDENTIALS`)
+- Compute Engine metadata (when running on GCP)
+
+## Azure Blob Storage
+
+### Setup
+
+```python
+write_ducklake(
+    df,
+    "catalog.ducklake",
+    "users",
+    mode="error",
+    data_path="az://my-container/warehouse/",
+)
+
+lf = scan_ducklake(
+    "catalog.ducklake",
+    "users",
+    data_path="az://my-container/warehouse/",
+)
+```
+
+### Authentication
+
+`adlfs` uses standard Azure credential resolution:
+
+- Environment variables (`AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_ACCOUNT_KEY`)
+- Azure CLI login (`az login`)
+- Managed Identity (when running on Azure)
+- Connection strings
+
+## Architecture
+
+```
+┌──────────────────────────┐
+│  SQLite / PostgreSQL     │  ← Catalog metadata (local or networked)
+│  (catalog.ducklake)      │
+└──────────┬───────────────┘
+           │ references
+           ▼
+┌──────────────────────────┐
+│  S3 / GCS / Azure        │  ← Parquet data files
+│  s3://bucket/data/       │
+└──────────────────────────┘
+```
+
+The catalog stores references to Parquet files with their paths. When the `data_path` is an object storage URI, ducklake-dataframe uses the corresponding fsspec filesystem to read and write the Parquet files.
+
+## Mixing local and remote
+
+You can keep the catalog metadata locally (fast, no network latency for metadata operations) while storing the actual data on object storage:
+
+```python
+# Catalog on local disk, data on S3
+write_ducklake(
+    df,
+    "/local/catalog.ducklake",      # local SQLite
+    "users",
+    mode="append",
+    data_path="s3://data-lake/warehouse/",  # remote data
+)
+```
+
+Or use PostgreSQL for the catalog and object storage for data — fully separating metadata from data:
+
+```python
+PG_DSN = "postgresql://user:pass@host/db"
+write_ducklake(df, PG_DSN, "users", mode="append", data_path="s3://data-lake/warehouse/")
+```
+
+## Known limitations
+
+- Object storage support is a current area of development. The local filesystem is the most tested path.
+- Large-scale object storage operations (thousands of files) may benefit from connection pooling and retry configuration in the underlying fsspec library.
+- Ensure the `data_path` parameter is consistent across all reads and writes to the same catalog — mismatched paths will cause file-not-found errors.

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -1,0 +1,194 @@
+# Time Travel
+
+DuckLake tracks every change to your tables as immutable snapshots. ducklake-dataframe lets you read any historical version of your data — by snapshot number or by timestamp.
+
+## How snapshots work
+
+Every write operation (insert, delete, update, merge, DDL) creates a new snapshot in the catalog. Each snapshot records:
+
+- **`snapshot_id`** — auto-incrementing integer
+- **`snapshot_time`** — timestamp when the snapshot was created
+- **`schema_version`** — tracks DDL changes (column adds, renames, type changes)
+
+Snapshots are immutable — old data is never modified, only superseded by new snapshots.
+
+## Reading historical data
+
+### By snapshot version
+
+```python
+from ducklake_polars import read_ducklake, scan_ducklake
+
+# Eager read at snapshot version 1
+df = read_ducklake("catalog.ducklake", "users", snapshot_version=1)
+
+# Lazy scan at snapshot version 3
+lf = scan_ducklake("catalog.ducklake", "users", snapshot_version=3)
+result = lf.filter(pl.col("region") == "US").collect()
+```
+
+### By timestamp
+
+```python
+from datetime import datetime
+
+# ISO format string
+df = read_ducklake("catalog.ducklake", "users", snapshot_time="2025-06-15T10:30:00")
+
+# datetime object
+ts = datetime(2025, 6, 15, 10, 30, 0)
+df = read_ducklake("catalog.ducklake", "users", snapshot_time=ts)
+```
+
+When using `snapshot_time`, the catalog returns the most recent snapshot at or before the given timestamp.
+
+### Constraints
+
+You cannot specify both `snapshot_version` and `snapshot_time` — doing so raises a `ValueError`:
+
+```python
+# This raises ValueError
+df = read_ducklake(
+    "catalog.ducklake", "users",
+    snapshot_version=1,
+    snapshot_time="2025-06-15T10:30:00",
+)
+```
+
+## Listing snapshots
+
+Use `DuckLakeCatalog` to inspect available snapshots:
+
+```python
+from ducklake_polars import DuckLakeCatalog
+
+catalog = DuckLakeCatalog("catalog.ducklake")
+
+# All snapshots
+snapshots = catalog.snapshots()
+print(snapshots)
+# shape: (5, 3)
+# ┌─────────────┬──────────────────────┬────────────────┐
+# │ snapshot_id ┆ snapshot_time        ┆ schema_version │
+# │ ---         ┆ ---                  ┆ ---            │
+# │ i64         ┆ str                  ┆ i64            │
+# ╞═════════════╪══════════════════════╪════════════════╡
+# │ 1           ┆ 2025-06-15T08:00:00  ┆ 1              │
+# │ 2           ┆ 2025-06-15T09:15:00  ┆ 1              │
+# │ 3           ┆ 2025-06-15T10:30:00  ┆ 2              │
+# │ 4           ┆ 2025-06-15T11:00:00  ┆ 2              │
+# │ 5           ┆ 2025-06-15T12:00:00  ┆ 2              │
+# └─────────────┴──────────────────────┴────────────────┘
+
+# Latest snapshot ID
+current = catalog.current_snapshot()
+print(current)  # 5
+```
+
+## Change data feed
+
+Track what changed between snapshots:
+
+```python
+catalog = DuckLakeCatalog("catalog.ducklake")
+
+# Rows inserted between snapshot 1 and 3
+insertions = catalog.table_insertions("users", start_version=1, end_version=3)
+
+# Rows deleted between snapshot 1 and 3
+deletions = catalog.table_deletions("users", start_version=1, end_version=3)
+
+# Full change data feed (inserts, deletes, updates as pre/post images)
+changes = catalog.table_changes("users", start_version=1, end_version=3)
+print(changes)
+# ┌─────────────┬────────────────────┬─────┬───────┬────────┐
+# │ snapshot_id ┆ change_type        ┆ id  ┆ name  ┆ region │
+# │ ---         ┆ ---                ┆ --- ┆ ---   ┆ ---    │
+# │ i64         ┆ str                ┆ i64 ┆ str   ┆ str    │
+# ╞═════════════╪════════════════════╪═════╪═══════╪════════╡
+# │ 2           ┆ insert             ┆ 4   ┆ Dave  ┆ EU     │
+# │ 3           ┆ update_preimage    ┆ 1   ┆ Alice ┆ US     │
+# │ 3           ┆ update_postimage   ┆ 1   ┆ Alice ┆ APAC   │
+# │ 3           ┆ delete             ┆ 2   ┆ Bob   ┆ EU     │
+# └─────────────┴────────────────────┴─────┴───────┴────────┘
+```
+
+The `change_type` column values:
+
+| Value | Meaning |
+|---|---|
+| `insert` | New row added |
+| `delete` | Row removed |
+| `update_preimage` | Row before an update (old values) |
+| `update_postimage` | Row after an update (new values) |
+
+Updates are detected when both an insertion and a deletion occur in the same snapshot for the same table.
+
+## Schema evolution across time
+
+Time travel handles schema evolution transparently:
+
+- **Added columns** — queries at snapshots before the column was added return `NULL` for that column
+- **Dropped columns** — queries at snapshots before the column was dropped still return the column's data
+- **Renamed columns** — column history is tracked, so old Parquet files with the old column name are reconciled automatically
+- **Type changes** — values from files written before a type change are cast to the new type on the fly
+
+```python
+# Column "email" was added at snapshot 3
+df_v2 = read_ducklake("catalog.ducklake", "users", snapshot_version=2)
+# "email" column is not present (it didn't exist yet)
+
+df_v4 = read_ducklake("catalog.ducklake", "users", snapshot_version=4)
+# "email" column is present; rows from before snapshot 3 have NULL
+```
+
+## Catalog inspection at specific versions
+
+Several `DuckLakeCatalog` methods accept a `snapshot_version` parameter:
+
+```python
+catalog = DuckLakeCatalog("catalog.ducklake")
+
+# List files at a specific snapshot
+files_v2 = catalog.list_files("users", snapshot_version=2)
+
+# List schemas at a specific snapshot
+schemas_v1 = catalog.list_schemas(snapshot_version=1)
+
+# List tables at a specific snapshot
+tables_v1 = catalog.list_tables(snapshot_version=1)
+```
+
+## Expiring snapshots
+
+Over time, old snapshots accumulate. Use `expire_snapshots` to clean up metadata and `vacuum_ducklake` to remove orphaned data files:
+
+```python
+from ducklake_polars import expire_snapshots, vacuum_ducklake
+
+# Keep only the last 10 snapshots
+expired = expire_snapshots("catalog.ducklake", keep_last_n=10)
+print(f"Expired {expired} snapshots")
+
+# Or expire by snapshot ID
+expired = expire_snapshots("catalog.ducklake", older_than_snapshot=5)
+
+# Then clean up orphaned Parquet files
+deleted = vacuum_ducklake("catalog.ducklake")
+print(f"Deleted {deleted} orphaned files")
+```
+
+!!! warning
+    After expiring snapshots, time travel to those versions is no longer possible. Only expire snapshots you're sure you don't need.
+
+## Pandas
+
+All time travel features work identically with the Pandas API:
+
+```python
+from ducklake_pandas import read_ducklake, DuckLakeCatalog
+
+df = read_ducklake("catalog.ducklake", "users", snapshot_version=1)
+catalog = DuckLakeCatalog("catalog.ducklake")
+changes = catalog.table_changes("users", start_version=1, end_version=5)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: ducklake-dataframe
+site_description: Polars & pandas wrappers for DuckLake catalogs
+theme:
+  name: material
+nav:
+  - Home: index.md
+  - API Reference: api.md
+  - Backends: backends.md
+  - Object Storage: object-storage.md
+  - Time Travel: time-travel.md
+  - Concurrency: concurrency.md


### PR DESCRIPTION
## Documentation site for ducklake-dataframe

Adds a complete MkDocs documentation site with Material theme.

### Pages

- **Home** (`docs/index.md`) — project overview, architecture diagram, installation instructions, quick start examples, feature summary
- **API Reference** (`docs/api.md`) — full API reference for both `ducklake_polars` and `ducklake_pandas`, documenting every public function with accurate signatures, parameters, return types, and usage examples
- **Backends** (`docs/backends.md`) — SQLite, PostgreSQL, and DuckDB catalog backend setup, comparison table, interoperability details
- **Object Storage** (`docs/object-storage.md`) — S3/GCS/Azure configuration via fsspec, authentication, architecture
- **Time Travel** (`docs/time-travel.md`) — snapshot versioning, reading historical data, change data feed, schema evolution across time, expiring snapshots
- **Concurrency** (`docs/concurrency.md`) — write model, `TransactionConflictError`, automatic retries with exponential backoff, backend-specific behavior, patterns

### Build

```bash
pip install mkdocs-material
mkdocs serve    # local preview
mkdocs build    # static site
```