### PR TITLE
ci: PyPI publish workflow with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,34 @@
 name: Publish to PyPI
-
 on:
   release:
     types: [published]
-
-permissions:
-  id-token: write
+  workflow_dispatch:
 
 jobs:
-  publish:
+  test:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.12']
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[polars,pandas,test]"
+      - run: python -m pytest tests/test_basic.py tests/test_pandas_basic.py -x -q
 
-      - name: Install build tools
-        run: pip install build
-
-      - name: Build package
-        run: python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a GitHub Actions workflow for automated PyPI publishing using trusted publishing (OIDC).

**What this does:**
- Runs tests on Python 3.9 and 3.12 before publishing
- Builds and publishes to PyPI on release creation
- Uses PyPA trusted publishing (no API tokens needed)
- Can also be triggered manually via `workflow_dispatch`

**Setup required on PyPI:**
- Configure trusted publisher for this repo under the `pypi` environment