### PR TITLE
feat: stateful DuckLakeCatalog write API

### DIFF
--- a/src/ducklake_polars/_catalog_api.py
+++ b/src/ducklake_polars/_catalog_api.py
@@ -299,3 +299,344 @@ class DuckLakeCatalog(_CoreCatalog):
         insertions become ``update_postimage``.
         """
         return pl.from_arrow(super().table_changes(table, start_version, end_version, schema=schema))
+
+    # ------------------------------------------------------------------
+    # Sort keys
+    # ------------------------------------------------------------------
+
+    def sort_keys(
+        self, table: str, *, schema: str = "main"
+    ) -> pl.DataFrame:
+        """
+        Get sort keys for a table.
+
+        Returns a DataFrame with columns:
+        - ``column_name`` (String)
+        - ``sort_order`` (String) — ``'ASC'`` or ``'DESC'``
+        """
+        return pl.from_arrow(super().sort_keys(table, schema=schema))
+
+    # ------------------------------------------------------------------
+    # Views
+    # ------------------------------------------------------------------
+
+    def list_views(
+        self, *, schema: str = "main", snapshot_version: int | None = None
+    ) -> pl.DataFrame:
+        """List views in a schema."""
+        return pl.from_arrow(
+            super().list_views(schema=schema, snapshot_version=snapshot_version)
+        )
+
+    def get_view(
+        self,
+        name: str,
+        *,
+        schema: str = "main",
+        snapshot_version: int | None = None,
+    ) -> pl.DataFrame:
+        """Get view definition."""
+        return pl.from_arrow(
+            super().get_view(name, schema=schema, snapshot_version=snapshot_version)
+        )
+
+    # ==================================================================
+    # Write operations — stateful wrappers around free functions
+    # ==================================================================
+
+    def scan(
+        self,
+        table: str,
+        *,
+        schema: str = "main",
+        snapshot_version: int | None = None,
+        snapshot_time: str | None = None,
+    ) -> pl.LazyFrame:
+        """Lazy scan a table. Returns a Polars LazyFrame with pushdown."""
+        from ducklake_polars import scan_ducklake
+
+        return scan_ducklake(
+            self._metadata_path,
+            table,
+            schema=schema,
+            snapshot_version=snapshot_version,
+            snapshot_time=snapshot_time,
+            data_path=self._data_path_override,
+        )
+
+    def read(
+        self,
+        table: str,
+        *,
+        schema: str = "main",
+        snapshot_version: int | None = None,
+        snapshot_time: str | None = None,
+    ) -> pl.DataFrame:
+        """Read a table eagerly. Returns a Polars DataFrame."""
+        from ducklake_polars import read_ducklake
+
+        return read_ducklake(
+            self._metadata_path,
+            table,
+            schema=schema,
+            snapshot_version=snapshot_version,
+            snapshot_time=snapshot_time,
+            data_path=self._data_path_override,
+        )
+
+    def write(
+        self,
+        table: str,
+        df: pl.DataFrame,
+        *,
+        schema: str = "main",
+        mode: str = "error",
+        data_inlining_row_limit: int = 0,
+        author: str | None = None,
+        commit_message: str | None = None,
+    ) -> None:
+        """Write a DataFrame to a table."""
+        from ducklake_polars import write_ducklake
+
+        write_ducklake(
+            df,
+            self._metadata_path,
+            table,
+            schema=schema,
+            mode=mode,
+            data_path=self._data_path_override,
+            data_inlining_row_limit=data_inlining_row_limit,
+            author=author,
+            commit_message=commit_message,
+        )
+
+    def delete(
+        self,
+        table: str,
+        predicate: pl.Expr,
+        *,
+        schema: str = "main",
+    ) -> int:
+        """Delete rows matching predicate. Returns deleted row count."""
+        from ducklake_polars import delete_ducklake
+
+        return delete_ducklake(
+            self._metadata_path,
+            table,
+            predicate,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def update(
+        self,
+        table: str,
+        updates: dict[str, object],
+        predicate: pl.Expr,
+        *,
+        schema: str = "main",
+    ) -> int:
+        """Update rows matching predicate. Returns updated row count."""
+        from ducklake_polars import update_ducklake
+
+        return update_ducklake(
+            self._metadata_path,
+            table,
+            updates,
+            predicate,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def merge(
+        self,
+        table: str,
+        source_df: pl.DataFrame,
+        on: str | list[str],
+        *,
+        schema: str = "main",
+        when_matched_update: dict[str, object] | bool | None = True,
+        when_not_matched_insert: bool = True,
+    ) -> dict:
+        """Merge (upsert) source into target table."""
+        from ducklake_polars import merge_ducklake
+
+        return merge_ducklake(
+            self._metadata_path,
+            table,
+            source_df,
+            on,
+            schema=schema,
+            when_matched_update=when_matched_update,
+            when_not_matched_insert=when_not_matched_insert,
+            data_path=self._data_path_override,
+        )
+
+    def create_table(
+        self,
+        table: str,
+        schema_def: dict[str, pl.DataType],
+        *,
+        schema: str = "main",
+    ) -> None:
+        """Create an empty table with the given schema."""
+        from ducklake_polars import create_ducklake_table
+
+        create_ducklake_table(
+            self._metadata_path,
+            table,
+            schema_def,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def drop_table(
+        self,
+        table: str,
+        *,
+        schema: str = "main",
+    ) -> None:
+        """Drop a table."""
+        from ducklake_polars import drop_ducklake_table
+
+        drop_ducklake_table(
+            self._metadata_path,
+            table,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def add_column(
+        self,
+        table: str,
+        column_name: str,
+        column_type: pl.DataType,
+        *,
+        schema: str = "main",
+    ) -> None:
+        """Add a column to a table."""
+        from ducklake_polars import alter_ducklake_add_column
+
+        alter_ducklake_add_column(
+            self._metadata_path,
+            table,
+            column_name,
+            column_type,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def drop_column(
+        self,
+        table: str,
+        column_name: str,
+        *,
+        schema: str = "main",
+    ) -> None:
+        """Drop a column from a table."""
+        from ducklake_polars import alter_ducklake_drop_column
+
+        alter_ducklake_drop_column(
+            self._metadata_path,
+            table,
+            column_name,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def rename_column(
+        self,
+        table: str,
+        old_name: str,
+        new_name: str,
+        *,
+        schema: str = "main",
+    ) -> None:
+        """Rename a column."""
+        from ducklake_polars import alter_ducklake_rename_column
+
+        alter_ducklake_rename_column(
+            self._metadata_path,
+            table,
+            old_name,
+            new_name,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def set_partitioned_by(
+        self,
+        table: str,
+        columns: list[str],
+        *,
+        schema: str = "main",
+    ) -> None:
+        """Set partition columns."""
+        from ducklake_polars import alter_ducklake_set_partitioned_by
+
+        alter_ducklake_set_partitioned_by(
+            self._metadata_path,
+            table,
+            columns,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def set_sort_keys(
+        self,
+        table: str,
+        keys: list[tuple[str, str]],
+        *,
+        schema_name: str = "main",
+    ) -> None:
+        """Set sort keys. keys = [(col, 'ASC'|'DESC'), ...]."""
+        from ducklake_polars import alter_ducklake_set_sort_keys
+
+        alter_ducklake_set_sort_keys(
+            self._metadata_path,
+            table,
+            keys,
+            schema=schema_name,
+            data_path=self._data_path_override,
+        )
+
+    def rewrite_data_files(
+        self,
+        table: str,
+        *,
+        schema: str = "main",
+    ) -> int:
+        """Compact data files. Returns new snapshot ID or -1 if no-op."""
+        from ducklake_polars import rewrite_data_files_ducklake
+
+        return rewrite_data_files_ducklake(
+            self._metadata_path,
+            table,
+            schema=schema,
+            data_path=self._data_path_override,
+        )
+
+    def expire_snapshots(
+        self,
+        *,
+        older_than: str | None = None,
+        retain_last: int | None = None,
+    ) -> int:
+        """Expire old snapshots. Returns number expired."""
+        from ducklake_polars import expire_snapshots
+
+        return expire_snapshots(
+            self._metadata_path,
+            older_than=older_than,
+            retain_last=retain_last,
+            data_path=self._data_path_override,
+        )
+
+    def vacuum(self) -> int:
+        """Remove orphaned data files. Returns count removed."""
+        from ducklake_polars import vacuum_ducklake
+
+        return vacuum_ducklake(
+            self._metadata_path,
+            data_path=self._data_path_override,
+        )

--- a/tests/test_catalog_object.py
+++ b/tests/test_catalog_object.py
@@ -1,0 +1,186 @@
+"""Tests for the stateful DuckLakeCatalog write API.
+
+The DuckLakeCatalog object wraps all free functions so users don't need
+to pass metadata_path/data_path to every call.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from ducklake_polars import DuckLakeCatalog
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    """Create a fresh DuckLakeCatalog backed by SQLite."""
+    import duckdb
+    import os
+
+    meta = str(tmp_path / "test.ducklake")
+    data = str(tmp_path / "data")
+    os.makedirs(data, exist_ok=True)
+
+    # Initialize via DuckDB
+    con = duckdb.connect()
+    con.install_extension("ducklake")
+    con.load_extension("ducklake")
+    con.execute(
+        f"ATTACH 'ducklake:sqlite:{meta}' AS ducklake "
+        f"(DATA_PATH '{data}', DATA_INLINING_ROW_LIMIT 0)"
+    )
+    con.close()
+
+    return DuckLakeCatalog(meta, data_path=data)
+
+
+class TestCatalogReadWrite:
+    """Basic read/write through catalog object."""
+
+    def test_write_and_read(self, catalog):
+        df = pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+        catalog.write("t", df)
+
+        result = catalog.read("t")
+        assert len(result) == 3
+        assert_frame_equal(result.sort("id"), df.sort("id"))
+
+    def test_write_append(self, catalog):
+        df1 = pl.DataFrame({"id": [1, 2]})
+        catalog.write("t", df1)
+
+        df2 = pl.DataFrame({"id": [3, 4]})
+        catalog.write("t", df2, mode="append")
+
+        result = catalog.read("t")
+        assert set(result["id"].to_list()) == {1, 2, 3, 4}
+
+    def test_write_overwrite(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1, 2, 3]}))
+        catalog.write("t", pl.DataFrame({"id": [10]}), mode="overwrite")
+
+        result = catalog.read("t")
+        assert result["id"].to_list() == [10]
+
+    def test_scan_lazy(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]}))
+
+        lf = catalog.scan("t")
+        assert isinstance(lf, pl.LazyFrame)
+
+        result = lf.filter(pl.col("id") > 1).collect()
+        assert len(result) == 2
+
+
+class TestCatalogDML:
+    """Delete, update, merge through catalog."""
+
+    def test_delete(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1, 2, 3]}))
+        catalog.delete("t", pl.col("id") == 2)
+
+        result = catalog.read("t")
+        assert set(result["id"].to_list()) == {1, 3}
+
+    def test_update(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1, 2], "name": ["a", "b"]}))
+        catalog.update("t", {"name": pl.lit("X")}, pl.col("id") == 1)
+
+        result = catalog.read("t")
+        row = result.filter(pl.col("id") == 1)
+        assert row["name"][0] == "X"
+
+    def test_merge_upsert(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1, 2], "val": ["a", "b"]}))
+        source = pl.DataFrame({"id": [2, 3], "val": ["B", "c"]})
+        catalog.merge("t", source, "id", when_matched_update=True)
+
+        result = catalog.read("t").sort("id")
+        assert result["val"].to_list() == ["a", "B", "c"]
+
+
+class TestCatalogDDL:
+    """Schema operations through catalog."""
+
+    def test_create_and_drop_table(self, catalog):
+        catalog.create_table("empty", {"id": pl.Int64, "name": pl.String})
+        tables = catalog.list_tables()
+        assert "empty" in tables["table_name"].to_list()
+
+        catalog.drop_table("empty")
+        tables2 = catalog.list_tables()
+        assert "empty" not in tables2["table_name"].to_list()
+
+    def test_add_drop_rename_column(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1], "a": ["x"]}))
+
+        catalog.add_column("t", "b", pl.Int64)
+        result = catalog.read("t")
+        assert "b" in result.columns
+
+        catalog.rename_column("t", "a", "name")
+        result = catalog.read("t")
+        assert "name" in result.columns
+        assert "a" not in result.columns
+
+        catalog.drop_column("t", "b")
+        result = catalog.read("t")
+        assert "b" not in result.columns
+
+
+class TestCatalogMaintenance:
+    """Compaction and maintenance through catalog."""
+
+    def test_rewrite_data_files(self, catalog):
+        for i in range(3):
+            catalog.write("t", pl.DataFrame({"id": [i]}), mode="append")
+
+        snap = catalog.rewrite_data_files("t")
+        assert snap > 0
+
+        result = catalog.read("t")
+        assert len(result) == 3
+
+    def test_rewrite_idempotent(self, catalog):
+        for i in range(3):
+            catalog.write("t", pl.DataFrame({"id": [i]}), mode="append")
+
+        catalog.rewrite_data_files("t")
+        snap2 = catalog.rewrite_data_files("t")
+        assert snap2 == -1
+
+
+class TestCatalogMetadata:
+    """Metadata queries through catalog."""
+
+    def test_snapshots(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1]}))
+        snaps = catalog.snapshots()
+        assert len(snaps) >= 1
+
+    def test_current_snapshot(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1]}))
+        snap = catalog.current_snapshot()
+        assert snap >= 1
+
+    def test_table_info(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1]}))
+        info = catalog.table_info()
+        assert len(info) >= 1
+
+    def test_list_files(self, catalog):
+        catalog.write("t", pl.DataFrame({"id": [1]}))
+        files = catalog.list_files("t")
+        assert len(files) >= 1
+
+
+class TestCatalogContextManager:
+    """Catalog works as context manager."""
+
+    def test_context_manager(self, catalog):
+        with catalog as cat:
+            cat.write("t", pl.DataFrame({"id": [1]}))
+            result = cat.read("t")
+            assert len(result) == 1


### PR DESCRIPTION
Extends DuckLakeCatalog with all write operations. Instead of:

```python
write_ducklake(df, "catalog.ducklake", "users", data_path="./data", mode="append")
result = read_ducklake("catalog.ducklake", "users", data_path="./data")
```

Users can now:

```python
cat = DuckLakeCatalog("catalog.ducklake", data_path="./data")
cat.write("users", df, mode="append")
cat.scan("users").filter(pl.col("age") > 30).collect()
cat.delete("users", pl.col("id") == 5)
cat.update("users", {"status": pl.lit("active")}, pl.col("age") > 18)
cat.merge("users", source_df, "id")
cat.rewrite_data_files("users")
```

16 tests, all passing.