### PR TITLE
feat: DuckLakeStreamWriter — buffered micro-batch ingestion

### DIFF
--- a/src/ducklake_polars/__init__.py
+++ b/src/ducklake_polars/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "expire_snapshots",
     "vacuum_ducklake",
     "rewrite_data_files_ducklake",
+    "DuckLakeStreamWriter",
     "create_ducklake_view",
     "drop_ducklake_view",
     "set_ducklake_table_tag",
@@ -185,6 +186,19 @@ def read_ducklake(
     return lf.collect()
 
 
+def _merge_schema(writer, df, table: str, schema: str, snap_id: int) -> None:
+    """Auto-merge DataFrame schema into existing table schema."""
+    import polars as pl
+    table_id = writer._table_exists(table, schema, snap_id)
+    if table_id is None:
+        return
+    existing_cols = writer._get_columns_for_table(table_id, snap_id)
+    existing_names = {col[1] for col in existing_cols}
+    for col_name, col_type in df.schema.items():
+        if col_name not in existing_names:
+            writer.add_column(table, col_name, col_type, schema_name=schema)
+
+
 def write_ducklake(
     df: pl.DataFrame,
     path: str | Path,
@@ -199,6 +213,7 @@ def write_ducklake(
     max_retries: int = 3,
     retry_wait_ms: float = 100,
     retry_backoff: float = 2.0,
+    schema_evolution: str = "strict",
 ) -> None:
     """
     Write a Polars DataFrame to a DuckLake table.
@@ -272,6 +287,8 @@ def write_ducklake(
         elif mode == "append":
             if table_id is None:
                 writer.create_table(table, dict(df.schema), schema_name=schema)
+            elif schema_evolution == "merge":
+                _merge_schema(writer, df, table, schema, snap_id)
             if not df.is_empty():
                 writer.insert_data(df, table, schema_name=schema)
 
@@ -1622,3 +1639,131 @@ def table_info(
     dp = os.fspath(data_path) if data_path is not None else None
     with DuckLakeCatalogReader(os.fspath(path), data_path_override=dp) as reader:
         return reader.table_info(table, schema)
+
+
+# ------------------------------------------------------------------
+# Streaming Writer
+# ------------------------------------------------------------------
+
+class DuckLakeStreamWriter:
+    """
+    Buffered streaming writer for micro-batch ingestion.
+
+    Accumulates rows in an internal buffer and flushes to DuckLake
+    when the buffer exceeds ``flush_threshold`` rows. Auto-compacts
+    on close if ``compact_on_close`` is True.
+
+    Parameters
+    ----------
+    path
+        Path to the DuckLake metadata catalog file.
+    table
+        Table name.
+    schema
+        Schema name (default: "main").
+    data_path
+        Override the data path stored in the catalog.
+    flush_threshold
+        Number of rows before auto-flush (default: 10000).
+    compact_on_close
+        Whether to run rewrite_data_files on close (default: True).
+    schema_evolution
+        Schema evolution mode: "strict" or "merge" (default: "strict").
+
+    Examples
+    --------
+    >>> with DuckLakeStreamWriter("catalog.ducklake", "events") as writer:
+    ...     for batch in kafka_consumer:
+    ...         writer.append(batch)  # auto-flushes at threshold
+    ...     # auto-compacts on close
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        table: str,
+        *,
+        schema: str = "main",
+        data_path: str | Path | None = None,
+        flush_threshold: int = 10_000,
+        compact_on_close: bool = True,
+        schema_evolution: str = "strict",
+    ) -> None:
+        import polars as pl
+
+        self._path = os.fspath(path)
+        self._table = table
+        self._schema = schema
+        self._data_path = os.fspath(data_path) if data_path is not None else None
+        self._flush_threshold = flush_threshold
+        self._compact_on_close = compact_on_close
+        self._schema_evolution = schema_evolution
+        self._buffer: list[pl.DataFrame] = []
+        self._buffer_rows = 0
+        self._total_rows = 0
+        self._flush_count = 0
+
+    def __enter__(self) -> DuckLakeStreamWriter:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def append(self, df: pl.DataFrame) -> None:
+        """Append a DataFrame to the buffer. Auto-flushes when threshold is reached."""
+        import polars as pl
+
+        if df.is_empty():
+            return
+        self._buffer.append(df)
+        self._buffer_rows += len(df)
+        if self._buffer_rows >= self._flush_threshold:
+            self.flush()
+
+    def flush(self) -> None:
+        """Write buffered data to DuckLake."""
+        import polars as pl
+
+        if not self._buffer:
+            return
+
+        combined = pl.concat(self._buffer) if len(self._buffer) > 1 else self._buffer[0]
+        write_ducklake(
+            combined,
+            self._path,
+            self._table,
+            schema=self._schema,
+            mode="append",
+            data_path=self._data_path,
+            schema_evolution=self._schema_evolution,
+        )
+        self._total_rows += len(combined)
+        self._flush_count += 1
+        self._buffer.clear()
+        self._buffer_rows = 0
+
+    def close(self) -> None:
+        """Flush remaining buffer and optionally compact."""
+        self.flush()
+        if self._compact_on_close and self._flush_count > 1:
+            rewrite_data_files_ducklake(
+                self._path,
+                self._table,
+                schema=self._schema,
+                data_path=self._data_path,
+            )
+
+    @property
+    def total_rows(self) -> int:
+        """Total rows written (flushed + buffered)."""
+        return self._total_rows + self._buffer_rows
+
+    @property
+    def flush_count(self) -> int:
+        """Number of flushes performed."""
+        return self._flush_count
+
+    @property
+    def buffer_rows(self) -> int:
+        """Current number of buffered rows."""
+        return self._buffer_rows

--- a/tests/test_stream_writer.py
+++ b/tests/test_stream_writer.py
@@ -1,0 +1,130 @@
+"""Tests for DuckLakeStreamWriter — buffered streaming ingestion."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from ducklake_polars import DuckLakeStreamWriter, read_ducklake
+
+
+@pytest.fixture
+def write_cat(make_write_catalog):
+    return make_write_catalog()
+
+
+class TestStreamWriterBasic:
+    """Basic streaming writer behavior."""
+
+    def test_context_manager_writes(self, write_cat):
+        cat = write_cat
+        with DuckLakeStreamWriter(cat.metadata_path, "t",
+                                  data_path=cat.data_path,
+                                  flush_threshold=100) as writer:
+            for i in range(5):
+                writer.append(pl.DataFrame({"id": [i]}))
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert len(result) == 5
+
+    def test_auto_flush_at_threshold(self, write_cat):
+        cat = write_cat
+        with DuckLakeStreamWriter(cat.metadata_path, "t",
+                                  data_path=cat.data_path,
+                                  flush_threshold=10) as writer:
+            # Write 25 rows in batches of 5
+            for i in range(5):
+                writer.append(pl.DataFrame({
+                    "id": list(range(i * 5, (i + 1) * 5)),
+                }))
+
+            # Should have auto-flushed at least twice (10, 20)
+            assert writer.flush_count >= 2
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert len(result) == 25
+
+    def test_empty_append_ignored(self, write_cat):
+        cat = write_cat
+        with DuckLakeStreamWriter(cat.metadata_path, "t",
+                                  data_path=cat.data_path,
+                                  flush_threshold=100) as writer:
+            writer.append(pl.DataFrame({"id": [1]}))
+            writer.append(pl.DataFrame({"id": pl.Series([], dtype=pl.Int64)}))
+            writer.append(pl.DataFrame({"id": [2]}))
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert len(result) == 2
+
+
+class TestStreamWriterCompaction:
+    """Auto-compaction on close."""
+
+    def test_compact_on_close(self, write_cat):
+        cat = write_cat
+        with DuckLakeStreamWriter(cat.metadata_path, "t",
+                                  data_path=cat.data_path,
+                                  flush_threshold=5,
+                                  compact_on_close=True) as writer:
+            for i in range(20):
+                writer.append(pl.DataFrame({"id": [i]}))
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert len(result) == 20
+
+    def test_no_compact_when_disabled(self, write_cat):
+        cat = write_cat
+        with DuckLakeStreamWriter(cat.metadata_path, "t",
+                                  data_path=cat.data_path,
+                                  flush_threshold=5,
+                                  compact_on_close=False) as writer:
+            for i in range(20):
+                writer.append(pl.DataFrame({"id": [i]}))
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert len(result) == 20
+
+
+class TestStreamWriterProperties:
+    """Writer properties: total_rows, flush_count, buffer_rows."""
+
+    def test_properties(self, write_cat):
+        cat = write_cat
+        writer = DuckLakeStreamWriter(cat.metadata_path, "t",
+                                      data_path=cat.data_path,
+                                      flush_threshold=10)
+        writer.append(pl.DataFrame({"id": list(range(7))}))
+        assert writer.buffer_rows == 7
+        assert writer.flush_count == 0
+        assert writer.total_rows == 7
+
+        writer.append(pl.DataFrame({"id": list(range(7, 15))}))
+        # Should have auto-flushed (15 > 10)
+        assert writer.flush_count >= 1
+        assert writer.total_rows == 15
+
+        writer.close()
+
+
+class TestStreamWriterSchemaEvolution:
+    """Streaming writer with schema_evolution='merge'."""
+
+    def test_evolving_schema(self, write_cat):
+        cat = write_cat
+        with DuckLakeStreamWriter(cat.metadata_path, "t",
+                                  data_path=cat.data_path,
+                                  flush_threshold=5,
+                                  schema_evolution="merge") as writer:
+            # First batch: id only
+            writer.append(pl.DataFrame({"id": [1, 2, 3, 4, 5]}))
+
+            # Second batch: id + name (new column)
+            writer.append(pl.DataFrame({"id": [6, 7, 8, 9, 10], "name": ["a", "b", "c", "d", "e"]}))
+
+        result = read_ducklake(cat.metadata_path, "t", data_path=cat.data_path)
+        assert len(result) == 10
+        assert "name" in result.columns
+        # Old rows have NULL for name
+        old = result.filter(pl.col("id") <= 5)
+        assert old["name"].null_count() == 5


### PR DESCRIPTION
```python
with DuckLakeStreamWriter("catalog.ducklake", "events",
                          flush_threshold=10000) as writer:
    for batch in kafka_consumer:
        writer.append(batch)  # auto-flushes at 10K rows
    # auto-compacts on close
```

7 tests: context manager, auto-flush, empty ignore, compaction, properties, schema evolution.