### PR TITLE
fix: rename ducklake-polars → ducklake-dataframe + fix merge type promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,78 @@ Pure-Python [Polars](https://pola.rs/), [Pandas](https://pandas.pydata.org/), an
 
 Reads and writes DuckLake metadata directly from SQLite, PostgreSQL, or DuckDB catalog files and scans the underlying Parquet data files through each engine's native Parquet reader or PyArrow. **No DuckDB runtime dependency.** With Polars you get lazy evaluation, predicate pushdown, projection pushdown, file pruning, and all other Polars optimizations out of the box. With Pandas you get familiar DataFrame ergonomics with partition and statistics-based file pruning. With PySpark you get distributed reads and writes with schema evolution and position-delete handling.
 
+## Why DuckLake?
+
+DuckLake's SQL-database-backed catalog (SQLite or PostgreSQL) turns operations that require rewriting JSON manifest files in Iceberg into simple indexed SQL queries. Here's how `ducklake-dataframe` compares to PyIceberg on identical workloads (100K rows, ARM64 4-core server):
+
+| Category | DuckLake | Iceberg | Speedup |
+|---|---|---|---|
+| **Streaming append** (100 × 1K-row batches) | 1.1s | 9.1s | **8×** |
+| **Scan after streaming** (100 small files) | 0.02s | 0.63s | **30×** |
+| **Schema evolution — rename** (50 ops) | 0.27s | 27.0s | **100×** |
+| **Schema evolution — add column** (50 ops) | 0.26s | 5.0s | **20×** |
+| **Upsert / merge** (50% overlap) | 0.64s | 6.9s | **11×** |
+| **Time travel** (read snapshot 50/100) | 0.01s | 0.26s | **26×** |
+| **Partition pruning** (1 of 20) | 0.01s | 0.04s | **3×** |
+| **Baseline read/write** | ~0.1s | ~0.1s | ~1× |
+
+> DuckLake is fastest where catalogs matter most: schema changes, snapshot lookups, streaming ingestion, and merge. Baseline read/write performance is comparable — the bottleneck there is Parquet I/O, not the catalog.
+>
+> Iceberg wins one benchmark: reads after 50 column renames, where its field-ID-based Parquet metadata avoids name-mapping resolution.
+
+<details>
+<summary>Full benchmark details and methodology</summary>
+
+**Hardware:** ARM64, 4 cores, 7.6 GiB RAM · **Software:** Python 3.11, Polars 1.38.1, PyArrow 23.0.1, DuckDB 1.4.4, PyIceberg 0.11.1, ducklake-dataframe v0.4.0
+
+**Streaming benchmark** (100 batches × 1K rows):
+
+| Scenario | DuckLake | Iceberg | Speedup |
+|---|---|---|---|
+| Streaming append | 1.10s (90K rows/s) | 9.08s (11K rows/s) | 8.2× |
+| Read-after-write | 0.32s (62K rows/s) | 2.07s (10K rows/s) | 6.4× |
+| Scan + filter | 0.02s (4.7M rows/s) | 0.63s (158K rows/s) | 29.5× |
+| Aggregation | 0.02s (5.0M rows/s) | 0.55s (183K rows/s) | 27.3× |
+| Compaction | 0.12s (100→1 files) | N/A | — |
+| Time travel | 0.003s | 0.011s | 3.6× |
+
+**Schema evolution** (50 ops, 100K rows):
+
+| Scenario | DuckLake | Iceberg | Speedup |
+|---|---|---|---|
+| Add column (50×) | 0.26s (196 ops/s) | 5.01s (10 ops/s) | 19.6× |
+| Read after adds | 0.02s (6.3M rows/s) | 0.04s (2.3M rows/s) | 2.8× |
+| Rename column (50×) | 0.27s (184 ops/s) | 27.0s (2 ops/s) | 99.5× |
+| Read after renames | 0.07s (1.4M rows/s) | 0.03s (3.6M rows/s) | 0.4× *(Iceberg faster)* |
+| Schema churn (50 cycles) | 0.53s (190 ops/s) | 3.73s (27 ops/s) | 7.1× |
+| Wide table projection (200→5 cols) | 0.02s (6.5M rows/s) | 0.03s (3.3M rows/s) | 2.0× |
+
+**DML** (100K rows, 20 delete rounds):
+
+| Scenario | DuckLake | Iceberg | Speedup |
+|---|---|---|---|
+| Selective delete (10%) | 0.08s (1.2M rows/s) | 0.12s (855K rows/s) | 1.4× |
+| Read after delete | 0.02s (4.5M rows/s) | 0.02s (3.9M rows/s) | 1.2× |
+| Bulk update (20%) | 0.10s (1.0M rows/s) | 0.10s (1.0M rows/s) | ~1.0× |
+| Upsert merge (50% overlap) | 0.64s (157K rows/s) | 6.91s (14K rows/s) | 10.9× |
+| Delete cascade (20 rounds) | 2.40s (42K rows/s) | 5.53s (18K rows/s) | 2.3× |
+
+**Catalog operations** (100 snapshots, 50K rows):
+
+| Scenario | DuckLake | Iceberg | Speedup |
+|---|---|---|---|
+| Cold start (create→read) | 0.33s | 0.47s | 1.4× |
+| Snapshot history (100) | 0.002s | 0.006s | 2.9× |
+| Multi-table list (100) | 0.001s | 0.003s | 2.8× |
+| Partition pruning (1/20) | 0.01s (8.9M rows/s) | 0.04s (2.8M rows/s) | 3.2× |
+| Time travel (snap 50/100) | 0.01s (2.5M rows/s) | 0.26s (99K rows/s) | 26.0× |
+
+Run the benchmarks yourself: `python benchmarks/bench_streaming.py --batches 100 --batch-size 1000`
+
+See the [full benchmark wiki](https://github.com/pdet/ducklake-dataframe/wiki/Benchmarks) for details.
+
+</details>
+
 ## Architecture
 
 ```

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ducklake-polars Tutorial\n",
+    "# ducklake-dataframe Tutorial\n",
     "\n",
-    "This notebook walks through all the main features of `ducklake-polars` — a pure-Python Polars integration for DuckLake catalogs.\n",
+    "This notebook walks through all the main features of `ducklake-dataframe` \u2014 a pure-Python Polars integration for DuckLake catalogs.\n",
     "\n",
     "We'll:\n",
     "1. Create a DuckLake catalog with DuckDB and populate it\n",
-    "2. Read it with ducklake-polars (lazy scans, time travel, schema evolution)\n",
-    "3. Write data back with ducklake-polars (INSERT, DELETE, UPDATE, MERGE)\n",
+    "2. Read it with ducklake-dataframe (lazy scans, time travel, schema evolution)\n",
+    "3. Write data back with ducklake-dataframe (INSERT, DELETE, UPDATE, MERGE)\n",
     "4. Verify everything from DuckDB\n",
     "5. Explore DDL, partitioning, data inlining, views, and catalog maintenance"
    ]
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "# Install/upgrade to latest versions\n",
-    "!pip install -U ducklake-polars\n",
+    "!pip install -U ducklake-dataframe[polars]\n",
     "!pip install duckdb==1.4.4"
    ]
   },
@@ -57,7 +57,7 @@
    "source": [
     "## 1. Initialize the Catalog with DuckDB\n",
     "\n",
-    "DuckLake catalogs must be initialized by DuckDB's DuckLake extension. This creates the metadata schema (snapshot tables, column tables, etc.) that ducklake-polars reads and writes."
+    "DuckLake catalogs must be initialized by DuckDB's DuckLake extension. This creates the metadata schema (snapshot tables, column tables, etc.) that ducklake-dataframe reads and writes."
    ]
   },
   {
@@ -120,7 +120,7 @@
     "        (5, 4, 'eu',   150.0, '2025-01-17 08:00:00')\n",
     "\"\"\")\n",
     "\n",
-    "# Close DuckDB so ducklake-polars can access the catalog\n",
+    "# Close DuckDB so ducklake-dataframe can access the catalog\n",
     "con.close()\n",
     "print(\"DuckDB: Created events table with 5 rows. Connection closed.\")"
    ]
@@ -129,9 +129,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Reading with ducklake-polars\n",
+    "## 2. Reading with ducklake-dataframe\n",
     "\n",
-    "No DuckDB needed — reads metadata from SQLite directly and scans Parquet files through Polars."
+    "No DuckDB needed \u2014 reads metadata from SQLite directly and scans Parquet files through Polars."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "\n",
     "# Eager read\n",
     "df = read_ducklake(CATALOG, \"users\")\n",
-    "print(\"read_ducklake — all users:\")\n",
+    "print(\"read_ducklake \u2014 all users:\")\n",
     "df"
    ]
   },
@@ -175,7 +175,7 @@
    "source": [
     "# Select specific columns\n",
     "df = read_ducklake(CATALOG, \"users\", columns=[\"id\", \"name\"])\n",
-    "print(\"Projection — only id and name:\")\n",
+    "print(\"Projection \u2014 only id and name:\")\n",
     "df"
    ]
   },
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Writing with ducklake-polars\n",
+    "## 4. Writing with ducklake-dataframe\n",
     "\n",
     "### 4a. Append rows\n",
     "\n",
@@ -258,7 +258,7 @@
     "write_ducklake(new_users, CATALOG, \"users\", mode=\"append\",\n",
     "               author=\"tutorial\", commit_message=\"Add Frank and Grace\")\n",
     "\n",
-    "print(\"After append — 7 users:\")\n",
+    "print(\"After append \u2014 7 users:\")\n",
     "read_ducklake(CATALOG, \"users\").sort(\"id\")"
    ]
   },
@@ -268,7 +268,7 @@
    "source": [
     "### 4b. Verify from DuckDB\n",
     "\n",
-    "DuckDB can read what ducklake-polars wrote — full interop."
+    "DuckDB can read what ducklake-dataframe wrote \u2014 full interop."
    ]
   },
   {
@@ -281,7 +281,7 @@
     "con.execute(\"LOAD ducklake\")\n",
     "con.execute(f\"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATA}/')\")\n",
     "\n",
-    "print(\"DuckDB reads ducklake-polars data:\")\n",
+    "print(\"DuckDB reads ducklake-dataframe data:\")\n",
     "con.execute(\"SELECT * FROM lake.users ORDER BY id\").pl()"
    ]
   },
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.close()  # release for ducklake-polars"
+    "con.close()  # release for ducklake-dataframe"
    ]
   },
   {
@@ -396,7 +396,7 @@
     "con.execute(\"LOAD ducklake\")\n",
     "con.execute(f\"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATA}/')\")\n",
     "\n",
-    "print(\"DuckDB sees all ducklake-polars changes:\")\n",
+    "print(\"DuckDB sees all ducklake-dataframe changes:\")\n",
     "con.execute(\"SELECT * FROM lake.users ORDER BY id\").pl()"
    ]
   },
@@ -435,13 +435,13 @@
     "    try:\n",
     "        df = read_ducklake(CATALOG, \"users\", snapshot_version=v)\n",
     "        if len(df) > 0:\n",
-    "            print(f\"\\nSnapshot {v} — original data ({len(df)} rows):\")\n",
+    "            print(f\"\\nSnapshot {v} \u2014 original data ({len(df)} rows):\")\n",
     "            print(df.sort(\"id\"))\n",
     "            break\n",
     "    except Exception:\n",
     "        continue\n",
     "\n",
-    "print(f\"\\nLatest snapshot — current data:\")\n",
+    "print(f\"\\nLatest snapshot \u2014 current data:\")\n",
     "print(read_ducklake(CATALOG, \"users\").sort(\"id\"))"
    ]
   },
@@ -490,7 +490,7 @@
     "    alter_ducklake_drop_column,\n",
     ")\n",
     "\n",
-    "# Add a column — existing rows get NULL\n",
+    "# Add a column \u2014 existing rows get NULL\n",
     "alter_ducklake_add_column(CATALOG, \"users\", \"department\", pl.String,\n",
     "                          author=\"tutorial\", commit_message=\"Add department column\")\n",
     "\n",
@@ -506,9 +506,9 @@
    "source": [
     "# Rename a column\n",
     "alter_ducklake_rename_column(CATALOG, \"users\", \"email\", \"contact_email\",\n",
-    "                              author=\"tutorial\", commit_message=\"Rename email → contact_email\")\n",
+    "                              author=\"tutorial\", commit_message=\"Rename email \u2192 contact_email\")\n",
     "\n",
-    "print(\"After RENAME COLUMN 'email' → 'contact_email':\")\n",
+    "print(\"After RENAME COLUMN 'email' \u2192 'contact_email':\")\n",
     "print(read_ducklake(CATALOG, \"users\").sort(\"id\"))"
    ]
   },
@@ -571,7 +571,7 @@
     "alter_ducklake_set_partitioned_by(CATALOG, \"events\", [\"region\"],\n",
     "                                   author=\"tutorial\", commit_message=\"Partition events by region\")\n",
     "\n",
-    "# Insert more events — they'll be written as partitioned Parquet files\n",
+    "# Insert more events \u2014 they'll be written as partitioned Parquet files\n",
     "# Note: DuckDB created event_id/user_id as INTEGER (Int32)\n",
     "new_events = pl.DataFrame({\n",
     "    \"event_id\": pl.Series([6, 7, 8, 9], dtype=pl.Int32),\n",
@@ -595,7 +595,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Partition pruning — only reads 'us' partition files\n",
+    "# Partition pruning \u2014 only reads 'us' partition files\n",
     "us_events = (\n",
     "    scan_ducklake(CATALOG, \"events\")\n",
     "    .filter(pl.col(\"region\") == \"us\")\n",
@@ -867,7 +867,7 @@
    "source": [
     "## 14. Final Verification: Full Roundtrip\n",
     "\n",
-    "Let's verify the complete state from both DuckDB and ducklake-polars."
+    "Let's verify the complete state from both DuckDB and ducklake-dataframe."
    ]
   },
   {
@@ -876,8 +876,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ducklake-polars view\n",
-    "print(\"=== ducklake-polars ===\")\n",
+    "# ducklake-dataframe view\n",
+    "print(\"=== ducklake-dataframe ===\")\n",
     "for table in [\"users\", \"events\", \"metrics\", \"region_summary\"]:\n",
     "    df = read_ducklake(CATALOG, table)\n",
     "    print(f\"\\n{table}: {len(df)} rows\")\n",
@@ -900,7 +900,7 @@
     "    result = con.execute(f\"SELECT COUNT(*) FROM lake.{table}\").fetchone()\n",
     "    print(f\"{table}: {result[0]} rows\")\n",
     "\n",
-    "print(\"\\nDuckDB — users:\")\n",
+    "print(\"\\nDuckDB \u2014 users:\")\n",
     "con.execute(\"SELECT * FROM lake.users ORDER BY id\").pl()"
    ]
   },
@@ -958,9 +958,9 @@
     "| **Change data feed** | `DuckLakeCatalog.table_changes()` |\n",
     "| **Catalog inspection** | `DuckLakeCatalog.snapshots/table_info/list_files/...` |\n",
     "| **Maintenance** | `expire_snapshots`, `vacuum_ducklake` |\n",
-    "| **DuckDB interop** | ✅ Full bidirectional |\n",
+    "| **DuckDB interop** | \u2705 Full bidirectional |\n",
     "\n",
-    "For the complete API reference, see the [wiki](https://github.com/pdet/ducklake-polars/wiki)."
+    "For the complete API reference, see the [wiki](https://github.com/pdet/ducklake-dataframe/wiki)."
    ]
   }
  ],

--- a/examples/tutorial_pandas.ipynb
+++ b/examples/tutorial_pandas.ipynb
@@ -1,0 +1,805 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ducklake-dataframe Pandas Tutorial\n",
+    "\n",
+    "This notebook walks through all the main features of `ducklake-dataframe` using the **Pandas** wrapper (`ducklake_pandas`).\n",
+    "\n",
+    "It mirrors the [Polars tutorial](tutorial.ipynb) so you can compare the two APIs side-by-side."
+   ],
+   "id": "md0"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Install/upgrade to latest versions\n",
+    "!pip install -U ducklake-dataframe[pandas] duckdb"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code1"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import tempfile\n",
+    "\n",
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# Work directory\n",
+    "WORKDIR = tempfile.mkdtemp(prefix=\"ducklake_pandas_tutorial_\")\n",
+    "CATALOG = os.path.join(WORKDIR, \"catalog.ducklake\")\n",
+    "DATAPATH = os.path.join(WORKDIR, \"data/\")\n",
+    "print(f\"Working directory: {WORKDIR}\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code2"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Initialize the Catalog with DuckDB\n",
+    "\n",
+    "DuckLake catalogs must be initialized using DuckDB.\n",
+    "After that, `ducklake_pandas` can read/write independently."
+   ],
+   "id": "md3"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "con = duckdb.connect()\n",
+    "con.execute(\"INSTALL ducklake; LOAD ducklake\")\n",
+    "con.execute(\n",
+    "    f\"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake \"\n",
+    "    f\"(DATA_PATH '{DATAPATH}')\"\n",
+    ")\n",
+    "con.execute(\"\"\"\n",
+    "    CREATE TABLE lake.users (\n",
+    "        id     INTEGER,\n",
+    "        name   VARCHAR,\n",
+    "        region VARCHAR\n",
+    "    )\n",
+    "\"\"\")\n",
+    "con.execute(\"\"\"\n",
+    "    INSERT INTO lake.users VALUES\n",
+    "        (1, 'Alice',   'us'),\n",
+    "        (2, 'Bob',     'eu'),\n",
+    "        (3, 'Charlie', 'us'),\n",
+    "        (4, 'Diana',   'eu'),\n",
+    "        (5, 'Eve',     'us')\n",
+    "\"\"\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code4"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Also create an events table for later\n",
+    "con.execute(\"\"\"\n",
+    "    CREATE TABLE lake.events (\n",
+    "        ts      TIMESTAMP,\n",
+    "        user_id INTEGER,\n",
+    "        action  VARCHAR,\n",
+    "        region  VARCHAR\n",
+    "    )\n",
+    "\"\"\")\n",
+    "con.execute(\"\"\"\n",
+    "    INSERT INTO lake.events VALUES\n",
+    "        ('2025-03-01 10:00:00', 1, 'login',  'us'),\n",
+    "        ('2025-03-01 10:05:00', 2, 'login',  'eu'),\n",
+    "        ('2025-03-01 10:10:00', 1, 'click',  'us'),\n",
+    "        ('2025-03-01 10:15:00', 3, 'login',  'us'),\n",
+    "        ('2025-03-01 10:20:00', 2, 'click',  'eu')\n",
+    "\"\"\")\n",
+    "con.close()\n",
+    "print(\"Catalog created with 'users' (5 rows) and 'events' (5 rows)\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Reading with ducklake_pandas\n",
+    "\n",
+    "No DuckDB needed \u2014 reads metadata from SQLite and data from Parquet directly.\n",
+    "\n",
+    "> **Key difference from Polars:** Pandas has no lazy API, so there's no `scan_ducklake`.\n",
+    "> Use `read_ducklake` with `predicate` and `columns` for pushdown."
+   ],
+   "id": "md6"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import read_ducklake\n",
+    "\n",
+    "# Eager read\n",
+    "df = read_ducklake(CATALOG, \"users\")\n",
+    "print(f\"Full table ({len(df)} rows):\")\n",
+    "df"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code7"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Predicate pushdown \u2014 lambda receives a DataFrame, returns a boolean Series\n",
+    "us_users = read_ducklake(\n",
+    "    CATALOG, \"users\",\n",
+    "    predicate=lambda d: d[\"region\"] == \"us\",\n",
+    ")\n",
+    "print(f\"US users only ({len(us_users)} rows):\")\n",
+    "us_users"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code8"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Column projection\n",
+    "names = read_ducklake(CATALOG, \"users\", columns=[\"id\", \"name\"])\n",
+    "names"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code9"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Catalog Inspection\n",
+    "\n",
+    "The `DuckLakeCatalog` class provides Python equivalents of DuckLake's catalog functions."
+   ],
+   "id": "md10"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import DuckLakeCatalog\n",
+    "\n",
+    "catalog = DuckLakeCatalog(CATALOG)\n",
+    "print(f\"Schemas:   {catalog.list_schemas()['schema_name'].tolist()}\")\n",
+    "print(f\"Tables:    {catalog.list_tables()['table_name'].tolist()}\")\n",
+    "print(f\"Snapshots: {len(catalog.snapshots())} total\")\n",
+    "print(f\"Current:   {catalog.current_snapshot()}\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code11"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "print(\"=== Table Info ===\")\n",
+    "print(catalog.table_info())\n",
+    "\n",
+    "print(\"\\n=== Files in 'users' ===\")\n",
+    "print(catalog.list_files(\"users\"))"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code12"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Writing with ducklake_pandas\n",
+    "\n",
+    "### 4a. Append rows"
+   ],
+   "id": "md13"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import write_ducklake\n",
+    "\n",
+    "new_users = pd.DataFrame({\n",
+    "    \"id\":     [6, 7],\n",
+    "    \"name\":   [\"Frank\", \"Grace\"],\n",
+    "    \"region\": [\"eu\", \"us\"],\n",
+    "})\n",
+    "write_ducklake(new_users, CATALOG, \"users\", mode=\"append\")\n",
+    "\n",
+    "print(f\"After append: {len(read_ducklake(CATALOG, 'users'))} rows\")\n",
+    "read_ducklake(CATALOG, \"users\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code14"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4b. Verify from DuckDB\n",
+    "\n",
+    "DuckDB can read what `ducklake_pandas` wrote \u2014 full interoperability."
+   ],
+   "id": "md15"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "con = duckdb.connect()\n",
+    "con.execute(\"LOAD ducklake\")\n",
+    "con.execute(f\"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATAPATH}')\")\n",
+    "print(con.execute(\"SELECT * FROM lake.users ORDER BY id\").df().to_string(index=False))"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code16"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "con.close()  # release for ducklake_pandas"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code17"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4c. Delete rows"
+   ],
+   "id": "md18"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import delete_ducklake\n",
+    "\n",
+    "deleted = delete_ducklake(\n",
+    "    CATALOG, \"users\",\n",
+    "    predicate=lambda d: d[\"id\"] == 2,\n",
+    ")\n",
+    "print(f\"Deleted {deleted} row(s)\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code19"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4d. Update rows"
+   ],
+   "id": "md20"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import update_ducklake\n",
+    "\n",
+    "updated = update_ducklake(\n",
+    "    CATALOG, \"users\",\n",
+    "    updates={\"region\": \"apac\"},\n",
+    "    predicate=lambda d: d[\"name\"] == \"Eve\",\n",
+    ")\n",
+    "print(f\"Updated {updated} row(s)\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code21"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4e. Merge (upsert)\n",
+    "\n",
+    "> **Pandas predicates** use lambdas on DataFrames \u2014 not `pl.col()` expressions."
+   ],
+   "id": "md22"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import merge_ducklake\n",
+    "\n",
+    "source = pd.DataFrame({\n",
+    "    \"id\":     [1, 8],\n",
+    "    \"name\":   [\"Alice2\", \"Hank\"],\n",
+    "    \"region\": [\"us\", \"eu\"],\n",
+    "})\n",
+    "rows_upd, rows_ins = merge_ducklake(\n",
+    "    CATALOG, \"users\", source, on=\"id\",\n",
+    "    when_matched_update=True,\n",
+    "    when_not_matched_insert=True,\n",
+    ")\n",
+    "print(f\"Merge: {rows_upd} updated, {rows_ins} inserted\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code23"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4f. Verify from DuckDB again"
+   ],
+   "id": "md24"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "con = duckdb.connect()\n",
+    "con.execute(\"LOAD ducklake\")\n",
+    "con.execute(f\"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATAPATH}')\")\n",
+    "print(con.execute(\"SELECT * FROM lake.users ORDER BY id\").df().to_string(index=False))"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code25"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "con.close()"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code26"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Time Travel\n",
+    "\n",
+    "Every write creates a new snapshot. We can read the table at any historical snapshot."
+   ],
+   "id": "md27"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "catalog = DuckLakeCatalog(CATALOG)\n",
+    "snapshots = catalog.snapshots()\n",
+    "print(f\"Total snapshots: {len(snapshots)}\")\n",
+    "snapshots[[\"snapshot_id\", \"snapshot_time\"]]"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code28"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Read at an earlier snapshot\n",
+    "snap_v = int(snapshots[\"snapshot_id\"].iloc[4])\n",
+    "old_df = read_ducklake(CATALOG, \"users\", snapshot_version=snap_v)\n",
+    "print(f\"At snapshot {snap_v}: {len(old_df)} rows\")\n",
+    "old_df"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code29"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Schema Evolution (DDL)\n",
+    "\n",
+    "### Add, rename, drop columns, and change types"
+   ],
+   "id": "md30"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import (\n",
+    "    alter_ducklake_add_column,\n",
+    "    alter_ducklake_rename_column,\n",
+    "    alter_ducklake_drop_column,\n",
+    "    alter_ducklake_set_type,\n",
+    ")\n",
+    "\n",
+    "# Add columns\n",
+    "alter_ducklake_add_column(CATALOG, \"users\", \"email\", \"VARCHAR\")\n",
+    "alter_ducklake_add_column(CATALOG, \"users\", \"department\", \"VARCHAR\")\n",
+    "print(\"Added 'email' and 'department' columns\")\n",
+    "\n",
+    "# Rename a column\n",
+    "alter_ducklake_rename_column(CATALOG, \"users\", \"email\", \"contact\")\n",
+    "print(\"Renamed email \u2192 contact\")\n",
+    "\n",
+    "# Drop a column\n",
+    "alter_ducklake_drop_column(CATALOG, \"users\", \"department\")\n",
+    "print(\"Dropped 'department'\")\n",
+    "\n",
+    "# Change type\n",
+    "alter_ducklake_set_type(CATALOG, \"users\", \"id\", \"BIGINT\")\n",
+    "print(\"Changed id: INTEGER \u2192 BIGINT\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code31"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify: DuckDB sees the schema changes\n",
+    "con = duckdb.connect()\n",
+    "con.execute(\"LOAD ducklake\")\n",
+    "con.execute(f\"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATAPATH}')\")\n",
+    "print(con.execute(\"DESCRIBE lake.users\").df().to_string(index=False))"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code32"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "con.close()"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code33"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Partitioned Writes\n",
+    "\n",
+    "Set partitioning on a table, then inserts automatically go into partition directories."
+   ],
+   "id": "md34"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import alter_ducklake_set_partitioned_by\n",
+    "\n",
+    "alter_ducklake_set_partitioned_by(CATALOG, \"events\", [\"region\"])\n",
+    "\n",
+    "new_events = pd.DataFrame({\n",
+    "    \"ts\":      pd.to_datetime([\"2025-03-02 09:00:00\", \"2025-03-02 09:05:00\"]),\n",
+    "    \"user_id\": [6, 7],\n",
+    "    \"action\":  [\"signup\", \"signup\"],\n",
+    "    \"region\":  [\"us\", \"eu\"],\n",
+    "})\n",
+    "write_ducklake(new_events, CATALOG, \"events\", mode=\"append\")\n",
+    "print(\"Appended partitioned events\")\n",
+    "\n",
+    "# Partition pruning \u2014 only reads 'us' partition files\n",
+    "us_events = read_ducklake(\n",
+    "    CATALOG, \"events\",\n",
+    "    predicate=lambda d: d[\"region\"] == \"us\",\n",
+    ")\n",
+    "print(f\"US events: {len(us_events)} rows (partition pruning)\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code35"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Data Inlining\n",
+    "\n",
+    "Small inserts can be stored directly in the catalog database (SQLite) to avoid tiny Parquet files."
+   ],
+   "id": "md36"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import create_ducklake_table\n",
+    "\n",
+    "create_ducklake_table(CATALOG, \"tiny\", {\"ts\": \"TIMESTAMP\", \"value\": \"DOUBLE\"})\n",
+    "\n",
+    "# Small insert \u2192 inlined in the catalog DB\n",
+    "small = pd.DataFrame({\n",
+    "    \"ts\":    pd.to_datetime([\"2025-01-01 00:00:00\"]),\n",
+    "    \"value\": [3.14],\n",
+    "})\n",
+    "write_ducklake(small, CATALOG, \"tiny\", mode=\"append\", data_inlining_row_limit=100)\n",
+    "print(f\"Inlined 1 row \u2192 {len(read_ducklake(CATALOG, 'tiny'))} rows total\")\n",
+    "\n",
+    "# Larger insert \u2192 Parquet\n",
+    "big = pd.DataFrame({\n",
+    "    \"ts\":    pd.to_datetime([f\"2025-01-01 00:00:{i:02d}\" for i in range(50)]),\n",
+    "    \"value\": [float(i) for i in range(50)],\n",
+    "})\n",
+    "write_ducklake(big, CATALOG, \"tiny\", mode=\"append\")\n",
+    "print(f\"After large append \u2192 {len(read_ducklake(CATALOG, 'tiny'))} rows total\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code37"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. CREATE TABLE AS\n",
+    "\n",
+    "Create a new table with data in a single atomic snapshot."
+   ],
+   "id": "md38"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import create_table_as_ducklake\n",
+    "\n",
+    "summary = (\n",
+    "    read_ducklake(CATALOG, \"events\")\n",
+    "    .groupby(\"region\")\n",
+    "    .size()\n",
+    "    .reset_index(name=\"cnt\")\n",
+    ")\n",
+    "create_table_as_ducklake(summary, CATALOG, \"region_summary\")\n",
+    "read_ducklake(CATALOG, \"region_summary\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code39"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Views"
+   ],
+   "id": "md40"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import create_ducklake_view, drop_ducklake_view, list_views\n",
+    "\n",
+    "create_ducklake_view(\n",
+    "    CATALOG, \"active_users\",\n",
+    "    \"SELECT id, name FROM users WHERE region = 'us'\",\n",
+    ")\n",
+    "print(\"Created view 'active_users'\")\n",
+    "\n",
+    "# Replace view\n",
+    "create_ducklake_view(\n",
+    "    CATALOG, \"active_users\",\n",
+    "    \"SELECT id, name, contact FROM users WHERE region = 'us'\",\n",
+    "    or_replace=True,\n",
+    ")\n",
+    "print(\"Replaced view 'active_users'\")\n",
+    "\n",
+    "print(f\"Views: {list_views(CATALOG)}\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code41"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 11. Tags"
+   ],
+   "id": "md42"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import (\n",
+    "    set_ducklake_table_tag,\n",
+    "    set_ducklake_column_tag,\n",
+    "    delete_ducklake_table_tag,\n",
+    ")\n",
+    "\n",
+    "set_ducklake_table_tag(CATALOG, \"users\", \"owner\", \"analytics-team\")\n",
+    "set_ducklake_table_tag(CATALOG, \"users\", \"pii\", \"true\")\n",
+    "set_ducklake_column_tag(CATALOG, \"users\", \"contact\", \"pii_type\", \"email\")\n",
+    "print(\"Set tags on users table and contact column\")\n",
+    "\n",
+    "delete_ducklake_table_tag(CATALOG, \"users\", \"pii\")\n",
+    "print(\"Deleted 'pii' tag\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code43"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 12. Schema and Table Management"
+   ],
+   "id": "md44"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import (\n",
+    "    create_ducklake_schema,\n",
+    "    drop_ducklake_schema,\n",
+    "    drop_ducklake_table,\n",
+    ")\n",
+    "\n",
+    "create_ducklake_schema(CATALOG, \"staging\")\n",
+    "create_ducklake_table(CATALOG, \"raw_data\", {\"x\": \"INTEGER\"}, schema=\"staging\")\n",
+    "print(\"Created staging.raw_data\")\n",
+    "\n",
+    "drop_ducklake_table(CATALOG, \"raw_data\", schema=\"staging\")\n",
+    "drop_ducklake_schema(CATALOG, \"staging\")\n",
+    "print(\"Dropped staging schema and table\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code45"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 13. Catalog Maintenance\n",
+    "\n",
+    "Clean up old snapshots and orphaned files."
+   ],
+   "id": "md46"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ducklake_pandas import expire_snapshots, vacuum_ducklake\n",
+    "\n",
+    "catalog = DuckLakeCatalog(CATALOG)\n",
+    "print(f\"Before: {len(catalog.snapshots())} snapshots\")\n",
+    "\n",
+    "expired = expire_snapshots(CATALOG, keep_last_n=3)\n",
+    "vacuumed = vacuum_ducklake(CATALOG)\n",
+    "print(f\"Expired {expired} snapshots, vacuumed {vacuumed} orphan files\")\n",
+    "\n",
+    "catalog = DuckLakeCatalog(CATALOG)\n",
+    "print(f\"After:  {len(catalog.snapshots())} snapshots\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code47"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 14. Final Verification"
+   ],
+   "id": "md48"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "print(\"=== ducklake_pandas ===\")\n",
+    "for tbl in [\"users\", \"events\", \"tiny\", \"region_summary\"]:\n",
+    "    n = len(read_ducklake(CATALOG, tbl))\n",
+    "    print(f\"  {tbl:20s} \u2192 {n} rows\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code49"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ],
+   "id": "md50"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "shutil.rmtree(WORKDIR)\n",
+    "print(f\"Cleaned up {WORKDIR}\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "id": "code51"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "This tutorial covered:\n",
+    "\n",
+    "| Feature | Functions Used |\n",
+    "|---------|---------------|\n",
+    "| **Read** | `read_ducklake(predicate=lambda d: ..., columns=[...])` |\n",
+    "| **Write** | `write_ducklake(mode=\"append\"/\"overwrite\")` |\n",
+    "| **Delete** | `delete_ducklake(predicate=lambda d: ...)` |\n",
+    "| **Update** | `update_ducklake(updates={...}, predicate=lambda d: ...)` |\n",
+    "| **Merge** | `merge_ducklake(source_df, on=\"key\")` |\n",
+    "| **Time travel** | `read_ducklake(snapshot_version=N)` |\n",
+    "| **Schema evolution** | `alter_ducklake_add_column`, `_rename_column`, `_drop_column`, `_set_type` |\n",
+    "| **Partitioning** | `alter_ducklake_set_partitioned_by` |\n",
+    "| **Data inlining** | `write_ducklake(data_inlining_row_limit=100)` |\n",
+    "| **CREATE TABLE AS** | `create_table_as_ducklake(df, ...)` |\n",
+    "| **Views** | `create_ducklake_view`, `list_views` |\n",
+    "| **Tags** | `set_ducklake_table_tag`, `set_ducklake_column_tag` |\n",
+    "| **Maintenance** | `expire_snapshots`, `vacuum_ducklake` |\n",
+    "| **Catalog inspect** | `DuckLakeCatalog.snapshots()`, `.list_tables()`, `.list_files()` |\n",
+    "\n",
+    "> **Key difference from Polars:** Pandas uses `lambda d: d[\"col\"] == value` for predicates instead of `pl.col(\"col\") == value`, and column types are passed as DuckDB type strings (`\"VARCHAR\"`, `\"BIGINT\"`) instead of Polars types (`pl.String`, `pl.Int64`)."
+   ],
+   "id": "md52"
+  }
+ ]
+}

--- a/examples/tutorial_pandas.py
+++ b/examples/tutorial_pandas.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+ducklake-dataframe Pandas Tutorial
+===================================
+
+This script walks through every major ducklake-dataframe feature using
+the **Pandas** wrapper (``ducklake_pandas``).  It mirrors the Polars
+tutorial notebook so you can compare the two APIs side-by-side.
+
+Requirements
+------------
+    pip install ducklake-dataframe[pandas] duckdb
+"""
+
+import os, shutil, tempfile, datetime
+import duckdb
+import pandas as pd
+import numpy as np
+
+# ── work directory ──────────────────────────────────────────────────
+WORKDIR  = tempfile.mkdtemp(prefix="ducklake_pandas_tutorial_")
+CATALOG  = os.path.join(WORKDIR, "catalog.ducklake")
+DATAPATH = os.path.join(WORKDIR, "data/")
+print(f"Working directory: {WORKDIR}")
+
+# ====================================================================
+# 1.  Initialize the catalog with DuckDB
+# ====================================================================
+print("\n" + "=" * 60)
+print("1.  Initialize the catalog")
+print("=" * 60)
+
+con = duckdb.connect()
+con.execute("INSTALL ducklake; LOAD ducklake")
+con.execute(
+    f"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake "
+    f"(DATA_PATH '{DATAPATH}')"
+)
+con.execute("""
+    CREATE TABLE lake.users (
+        id     INTEGER,
+        name   VARCHAR,
+        region VARCHAR
+    )
+""")
+con.execute("""
+    INSERT INTO lake.users VALUES
+        (1, 'Alice',   'us'),
+        (2, 'Bob',     'eu'),
+        (3, 'Charlie', 'us'),
+        (4, 'Diana',   'eu'),
+        (5, 'Eve',     'us')
+""")
+con.execute("""
+    CREATE TABLE lake.events (
+        ts     TIMESTAMP,
+        user_id INTEGER,
+        action  VARCHAR,
+        region  VARCHAR
+    )
+""")
+con.execute("""
+    INSERT INTO lake.events VALUES
+        ('2025-03-01 10:00:00', 1, 'login',  'us'),
+        ('2025-03-01 10:05:00', 2, 'login',  'eu'),
+        ('2025-03-01 10:10:00', 1, 'click',  'us'),
+        ('2025-03-01 10:15:00', 3, 'login',  'us'),
+        ('2025-03-01 10:20:00', 2, 'click',  'eu')
+""")
+con.close()
+print("Catalog created with 'users' (5 rows) and 'events' (5 rows)")
+
+
+# ====================================================================
+# 2.  Reading with ducklake_pandas
+# ====================================================================
+print("\n" + "=" * 60)
+print("2.  Reading")
+print("=" * 60)
+
+from ducklake_pandas import read_ducklake
+
+df = read_ducklake(CATALOG, "users")
+print(f"\nFull table ({len(df)} rows):")
+print(df.to_string(index=False))
+
+# Predicate pushdown – lambda receives a DataFrame, returns a boolean Series
+us_users = read_ducklake(
+    CATALOG, "users",
+    predicate=lambda d: d["region"] == "us",
+)
+print(f"\nUS users only ({len(us_users)} rows):")
+print(us_users.to_string(index=False))
+
+# Column projection
+names = read_ducklake(CATALOG, "users", columns=["id", "name"])
+print(f"\nProjected columns: {list(names.columns)}")
+
+
+# ====================================================================
+# 3.  Catalog inspection
+# ====================================================================
+print("\n" + "=" * 60)
+print("3.  Catalog inspection")
+print("=" * 60)
+
+from ducklake_pandas import DuckLakeCatalog
+
+catalog = DuckLakeCatalog(CATALOG)
+print(f"Schemas : {catalog.list_schemas()}")
+print(f"Tables  : {list(catalog.list_tables()['table_name'])}")
+print(f"Snapshots: {len(catalog.snapshots())} total, current = {catalog.current_snapshot()}")
+print(f"\nTable info:\n{catalog.table_info()}")
+
+
+# ====================================================================
+# 4.  Writing
+# ====================================================================
+print("\n" + "=" * 60)
+print("4.  Writing")
+print("=" * 60)
+
+# ── 4a. Append ──────────────────────────────────────────────────────
+from ducklake_pandas import write_ducklake
+
+new_users = pd.DataFrame({
+    "id":     [6, 7],
+    "name":   ["Frank", "Grace"],
+    "region": ["eu", "us"],
+})
+write_ducklake(new_users, CATALOG, "users", mode="append")
+print(f"After append: {len(read_ducklake(CATALOG, 'users'))} rows")
+
+# ── 4b. DuckDB interop ─────────────────────────────────────────────
+con = duckdb.connect()
+con.execute("LOAD ducklake")
+con.execute(f"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATAPATH}')")
+print(f"DuckDB sees: {con.execute('SELECT COUNT(*) FROM lake.users').fetchone()[0]} rows")
+con.close()
+
+# ── 4c. Delete ──────────────────────────────────────────────────────
+from ducklake_pandas import delete_ducklake
+
+deleted = delete_ducklake(
+    CATALOG, "users",
+    predicate=lambda d: d["id"] == 2,
+)
+print(f"\nDeleted {deleted} row (Bob)")
+
+# ── 4d. Update ──────────────────────────────────────────────────────
+from ducklake_pandas import update_ducklake
+
+updated = update_ducklake(
+    CATALOG, "users",
+    updates={"region": "apac"},
+    predicate=lambda d: d["name"] == "Eve",
+)
+print(f"Updated {updated} row (Eve → apac)")
+
+# ── 4e. Merge ───────────────────────────────────────────────────────
+from ducklake_pandas import merge_ducklake
+
+source = pd.DataFrame({
+    "id":     [1, 8],
+    "name":   ["Alice2", "Hank"],
+    "region": ["us", "eu"],
+})
+rows_upd, rows_ins = merge_ducklake(
+    CATALOG, "users", source, on="id",
+    when_matched_update=True,
+    when_not_matched_insert=True,
+)
+print(f"Merge: {rows_upd} updated, {rows_ins} inserted")
+
+# ── 4f. Verify ──────────────────────────────────────────────────────
+print(f"\nFinal users ({len(read_ducklake(CATALOG, 'users'))} rows):")
+print(read_ducklake(CATALOG, "users").sort_values("id").to_string(index=False))
+
+
+# ====================================================================
+# 5.  Time travel
+# ====================================================================
+print("\n" + "=" * 60)
+print("5.  Time travel")
+print("=" * 60)
+
+catalog = DuckLakeCatalog(CATALOG)
+snapshots = catalog.snapshots()
+print(f"Snapshots:\n{snapshots[['snapshot_id', 'snapshot_time']].to_string(index=False)}")
+
+# Pick the snapshot after the initial INSERT (not the empty CREATE TABLE snapshot)
+snap_v = int(snapshots["snapshot_id"].iloc[-2])  # second-to-last
+old_df = read_ducklake(CATALOG, "users", snapshot_version=snap_v)
+print(f"\nAt snapshot {snap_v}: {len(old_df)} rows")
+print(old_df.to_string(index=False))
+
+
+# ====================================================================
+# 6.  Schema evolution
+# ====================================================================
+print("\n" + "=" * 60)
+print("6.  Schema evolution")
+print("=" * 60)
+
+from ducklake_pandas import (
+    alter_ducklake_add_column,
+    alter_ducklake_rename_column,
+    alter_ducklake_drop_column,
+    alter_ducklake_set_type,
+)
+
+alter_ducklake_add_column(CATALOG, "users", "email", "VARCHAR")
+print("Added 'email' column")
+
+alter_ducklake_add_column(CATALOG, "users", "department", "VARCHAR")
+print("Added 'department' column")
+
+alter_ducklake_rename_column(CATALOG, "users", "email", "contact")
+print("Renamed email → contact")
+
+alter_ducklake_drop_column(CATALOG, "users", "department")
+print("Dropped 'department' column")
+
+alter_ducklake_set_type(CATALOG, "users", "id", "BIGINT")
+print("Changed id type to BIGINT")
+
+df = read_ducklake(CATALOG, "users")
+print(f"\nSchema after evolution: {list(df.dtypes.items())}")
+
+
+# ====================================================================
+# 7.  Partitioned writes
+# ====================================================================
+print("\n" + "=" * 60)
+print("7.  Partitioned writes")
+print("=" * 60)
+
+from ducklake_pandas import alter_ducklake_set_partitioned_by
+
+alter_ducklake_set_partitioned_by(CATALOG, "events", ["region"])
+print("Set events partitioned by region")
+
+new_events = pd.DataFrame({
+    "ts":      pd.to_datetime(["2025-03-02 09:00:00", "2025-03-02 09:05:00"]),
+    "user_id": [6, 7],
+    "action":  ["signup", "signup"],
+    "region":  ["us", "eu"],
+})
+write_ducklake(new_events, CATALOG, "events", mode="append")
+
+us_events = read_ducklake(
+    CATALOG, "events",
+    predicate=lambda d: d["region"] == "us",
+)
+print(f"US events: {len(us_events)} rows (partition pruning)")
+
+
+# ====================================================================
+# 8.  Data inlining
+# ====================================================================
+print("\n" + "=" * 60)
+print("8.  Data inlining")
+print("=" * 60)
+
+from ducklake_pandas import create_ducklake_table
+
+create_ducklake_table(CATALOG, "tiny", {"ts": "TIMESTAMP", "value": "DOUBLE"})
+
+# Small insert → inlined in the catalog DB
+small = pd.DataFrame({
+    "ts":    pd.to_datetime(["2025-01-01 00:00:00"]),
+    "value": [3.14],
+})
+write_ducklake(small, CATALOG, "tiny", mode="append", data_inlining_row_limit=100)
+print(f"Inlined 1 row, table has {len(read_ducklake(CATALOG, 'tiny'))} rows")
+
+# Larger insert → Parquet
+big = pd.DataFrame({
+    "ts":    pd.to_datetime([f"2025-01-01 00:00:{i:02d}" for i in range(50)]),
+    "value": [float(i) for i in range(50)],
+})
+write_ducklake(big, CATALOG, "tiny", mode="append")
+print(f"After large append: {len(read_ducklake(CATALOG, 'tiny'))} rows")
+
+
+# ====================================================================
+# 9.  CREATE TABLE AS
+# ====================================================================
+print("\n" + "=" * 60)
+print("9.  CREATE TABLE AS")
+print("=" * 60)
+
+from ducklake_pandas import create_table_as_ducklake
+
+summary = read_ducklake(CATALOG, "events").groupby("region").size().reset_index(name="cnt")
+create_table_as_ducklake(summary, CATALOG, "region_summary")
+print(f"Created region_summary:\n{read_ducklake(CATALOG, 'region_summary').to_string(index=False)}")
+
+
+# ====================================================================
+# 10. Views
+# ====================================================================
+print("\n" + "=" * 60)
+print("10. Views")
+print("=" * 60)
+
+from ducklake_pandas import create_ducklake_view, drop_ducklake_view
+
+create_ducklake_view(
+    CATALOG, "active_users",
+    "SELECT id, name FROM users WHERE region = 'us'",
+)
+print("Created view 'active_users'")
+
+# Replace view
+create_ducklake_view(
+    CATALOG, "active_users",
+    "SELECT id, name, contact FROM users WHERE region = 'us'",
+    or_replace=True,
+)
+print("Replaced view 'active_users'")
+
+# Read view definition via DuckDB
+con = duckdb.connect()
+con.execute("LOAD ducklake")
+con.execute(f"ATTACH 'ducklake:sqlite:{CATALOG}' AS lake (DATA_PATH '{DATAPATH}')")
+from ducklake_pandas import list_views
+print(f"Views in catalog: {list_views(CATALOG)}")
+con.close()
+
+
+# ====================================================================
+# 11. Tags
+# ====================================================================
+print("\n" + "=" * 60)
+print("11. Tags")
+print("=" * 60)
+
+from ducklake_pandas import (
+    set_ducklake_table_tag,
+    set_ducklake_column_tag,
+    delete_ducklake_table_tag,
+)
+
+set_ducklake_table_tag(CATALOG, "users", "owner", "analytics-team")
+set_ducklake_table_tag(CATALOG, "users", "pii", "true")
+set_ducklake_column_tag(CATALOG, "users", "contact", "pii_type", "email")
+print("Set tags on users table and contact column")
+
+delete_ducklake_table_tag(CATALOG, "users", "pii")
+print("Deleted 'pii' tag")
+
+
+# ====================================================================
+# 12. Schema and table management
+# ====================================================================
+print("\n" + "=" * 60)
+print("12. Schema and table management")
+print("=" * 60)
+
+from ducklake_pandas import (
+    create_ducklake_schema,
+    drop_ducklake_schema,
+    rename_ducklake_table,
+    drop_ducklake_table,
+)
+
+create_ducklake_schema(CATALOG, "staging")
+print("Created 'staging' schema")
+create_ducklake_table(CATALOG, "raw_data", {"x": "INTEGER"}, schema="staging")
+print("Created staging.raw_data")
+drop_ducklake_table(CATALOG, "raw_data", schema="staging")
+print("Dropped staging.raw_data")
+drop_ducklake_schema(CATALOG, "staging")
+print("Dropped 'staging' schema")
+
+
+# ====================================================================
+# 13. Maintenance
+# ====================================================================
+print("\n" + "=" * 60)
+print("13. Maintenance")
+print("=" * 60)
+
+from ducklake_pandas import expire_snapshots, vacuum_ducklake
+
+catalog = DuckLakeCatalog(CATALOG)
+print(f"Before: {len(catalog.snapshots())} snapshots")
+
+expired = expire_snapshots(CATALOG, keep_last_n=3)
+print(f"Expired {expired} snapshots")
+
+vacuumed = vacuum_ducklake(CATALOG)
+print(f"Vacuumed {vacuumed} orphan files")
+
+catalog = DuckLakeCatalog(CATALOG)
+print(f"After:  {len(catalog.snapshots())} snapshots")
+
+
+# ====================================================================
+# 14. Final roundtrip verification
+# ====================================================================
+print("\n" + "=" * 60)
+print("14. Final roundtrip verification")
+print("=" * 60)
+
+print("=== ducklake_pandas ===")
+for tbl in ["users", "events", "tiny", "region_summary"]:
+    n = len(read_ducklake(CATALOG, tbl))
+    print(f"  {tbl:20s} → {n} rows")
+
+
+
+# ====================================================================
+# Cleanup
+# ====================================================================
+shutil.rmtree(WORKDIR)
+print(f"\nCleaned up {WORKDIR}")
+print("\n✅  ALL DONE — Pandas tutorial complete!")

--- a/src/ducklake_core/_writer.py
+++ b/src/ducklake_core/_writer.py
@@ -2638,7 +2638,7 @@ class DuckLakeCatalogWriter:
 
         if not all_matched:
             return None
-        return pa.concat_tables(all_matched) if len(all_matched) > 1 else all_matched[0]
+        return pa.concat_tables(all_matched, promote_options="permissive") if len(all_matched) > 1 else all_matched[0]
 
     @_retryable
     def update_data(
@@ -2729,7 +2729,7 @@ class DuckLakeCatalogWriter:
         if total_updated == 0:
             return 0
 
-        all_matched = pa.concat_tables(matched_dfs) if len(matched_dfs) > 1 else matched_dfs[0]
+        all_matched = pa.concat_tables(matched_dfs, promote_options="permissive") if len(matched_dfs) > 1 else matched_dfs[0]
 
         # Apply updates
         for col_name, value in updates.items():
@@ -2914,7 +2914,7 @@ class DuckLakeCatalogWriter:
 
         if not all_tables:
             return None
-        return pa.concat_tables(all_tables) if len(all_tables) > 1 else all_tables[0]
+        return pa.concat_tables(all_tables, promote_options="permissive") if len(all_tables) > 1 else all_tables[0]
 
     @staticmethod
     def _build_key_match_predicate(
@@ -3063,7 +3063,7 @@ class DuckLakeCatalogWriter:
         if when_not_matched_insert:
             if all_target_key_dfs:
                 all_target_keys = _unique_rows(
-                    pa.concat_tables(all_target_key_dfs)
+                    pa.concat_tables(all_target_key_dfs, promote_options="permissive")
                 )
                 unmatched_source = _anti_join(source_df, all_target_keys, on)
             else:
@@ -3083,7 +3083,7 @@ class DuckLakeCatalogWriter:
 
         if when_matched_update is not None and matched_target_dfs:
             all_matched = (
-                pa.concat_tables(matched_target_dfs)
+                pa.concat_tables(matched_target_dfs, promote_options="permissive")
                 if len(matched_target_dfs) > 1
                 else matched_target_dfs[0]
             )
@@ -3113,7 +3113,7 @@ class DuckLakeCatalogWriter:
             return (0, 0)
 
         insert_df = (
-            pa.concat_tables(rows_to_insert_parts)
+            pa.concat_tables(rows_to_insert_parts, promote_options="permissive")
             if len(rows_to_insert_parts) > 1
             else rows_to_insert_parts[0]
         )
@@ -4373,7 +4373,7 @@ class DuckLakeCatalogWriter:
                 all_dfs.append(active_df)
 
         if all_dfs:
-            combined = pa.concat_tables(all_dfs, promote_options="default") if len(all_dfs) > 1 else all_dfs[0]
+            combined = pa.concat_tables(all_dfs, promote_options="permissive") if len(all_dfs) > 1 else all_dfs[0]
         else:
             combined = pa.table(
                 {c[1]: pa.array([], type=pa.string()) for c in columns}


### PR DESCRIPTION
## Changes

### 1. Tutorial notebook: stale name references
All `ducklake-polars` (old project name) references in `examples/tutorial.ipynb` updated to `ducklake-dataframe`:
- Title: "ducklake-polars Tutorial" → "ducklake-dataframe Tutorial"  
- pip install: `!pip install -U ducklake-polars` → `!pip install -U ducklake-dataframe[polars]`
- All prose references updated

Python imports (`from ducklake_polars import ...`) left unchanged — those are real module names.

README.md and docs/ were already clean (no stale references found).

### 2. Fix `pa.concat_tables` type promotion in DML operations
Changed all `pa.concat_tables()` calls in merge/update/delete to use `promote_options='permissive'` so that schema evolution (e.g. `INTEGER→BIGINT` via `alter_ducklake_set_type`) doesn't crash DML operations that read old Parquet files with the original column types.

Without this fix, this sequence crashes:
```python
alter_ducklake_set_type(catalog, 'users', 'id', 'BIGINT')  # int32 → int64
merge_ducklake(catalog, 'users', source, on='id', ...)     # ArrowInvalid: int32 vs int64
```

**Affected calls (6 total):**
- `merge_data`: 3 concat_tables calls
- `update_data`: 1 concat_tables call
- `delete_data`: 1 concat_tables call
- `_read_file_rows`: 1 concat_tables call (already had `promote_options='default'`, upgraded to `'permissive'`)

## Verification
- ✅ All README examples run end-to-end
- ✅ Tutorial notebook executes via `nbconvert --execute`
- ✅ Test suite: 821 passed, 4 skipped, 7 xfailed (1 PySpark error = no Java on CI host)